### PR TITLE
Added desktop/mypaint-ora-thumbnailer to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ TAGS
 tags
 brushlib/*-gen.h
 brushlib/mypaint-config.h
+desktop/mypaint-ora-thumbnailer
 lib/test-python-surface
 lib/_mypaintlib.so
 lib/mypaintlib.py


### PR DESCRIPTION
It wasn't there before and it probably should've been, seeing as it's generated from desktop/mypaint-ora-thumbnailer.py.
