### PR TITLE
Popup Menu Fix

### DIFF
--- a/gui/toolbar.py
+++ b/gui/toolbar.py
@@ -109,7 +109,7 @@ class ToolbarManager (object):
 
         def _posfunc(*a):
             return x, y, True
-        time = gdk.CURRENT_TIME
+        time = gtk.get_current_event_time()
         # GTK3: arguments have a different order, and "data" is required.
         # GTK3: Use keyword arguments for max compatibility.
         menu.popup(parent_menu_shell=None, parent_menu_item=None,


### PR DESCRIPTION
Address the Problem in issue #94 where using a two finger
tap/press(right-click) on Multi-Touch touchpads and clickpads causes the toolbar
menu immediately unfocus. This was cause by the gdk.CURRENT_TIME. The
fix was to use the gtk.get_current_event_time() which was used in
the popup menu for the layers window.

This should fix #94
