### PR TITLE
Changed Zoom Tool functionality to keep centred on the middle of the canvas instead of on the mouse

### DIFF
--- a/gui/viewmanip.py
+++ b/gui/viewmanip.py
@@ -79,8 +79,7 @@ class ZoomViewMode (gui.mode.OneshotDragMode):
             self.ACTION_NAME)
 
     def drag_update_cb(self, tdw, event, dx, dy):
-        tdw.scroll(-dx, -dy)
-        tdw.zoom(math.exp(dy/100.0), center=(event.x, event.y))
+        tdw.zoom(math.exp(dy/100.0), center=tdw.get_center())
         # TODO: Let modifiers constrain the zoom amount to
         #       the defined steps.
         self.doc.notify_view_changed()


### PR DESCRIPTION
Playing around with this change for a bit felt a lot more convenient and consistent than the previous functionality, but I'm still making this a PR as it is a potentially significant user-facing change, so it probably needs feedback.

It definitely feels a lot better when using it as ctrl+middlemouse along with the rotating shift+middlemouse.