### PR TITLE
zero pixels outside of the frame when trimming

### DIFF
--- a/lib/layer.py
+++ b/lib/layer.py
@@ -3530,6 +3530,9 @@ class SurfaceBackedLayer (LayerBase):
         :type rect: tuple (x, y, w, h)
 
         Only complete tiles are discarded by this method.
+        If a tile is neither fully inside nor fully outside the
+        rectangle, the part of the tile outside the rectangle will be
+        cleared.
         """
         self._surface.trim(rect)
 


### PR DESCRIPTION
A tentative fix for https://github.com/mypaint/mypaint/issues/145.

Tentative because I'm not sure what a "background tile" is or how that would affect the fixing of this issue.

I found another trim() function in lib/strokemap.py when I grepped for 'Only complete tiles'. Am I correct in thinking that that's a separate problem?