### PR TITLE
make it clear when the old configuration area is being used

### DIFF
--- a/mypaint.py
+++ b/mypaint.py
@@ -196,9 +196,10 @@ def get_paths():
         if not os.path.isdir(old_confpath):
             old_confpath = None
         else:
-            logger.info("Found old-style configuration in %r", old_confpath)
-            logger.info("This can be migrated to $XDG_CONFIG_HOME and "
-                        "$XDG_DATA_HOME if you wish.")
+            logger.info("Using the old-style configuration area found in %r",
+                        old_confpath)
+            logger.info("Its contents can be migrated to $XDG_CONFIG_HOME"
+                        "and $XDG_DATA_HOME if you wish.")
             logger.info("See the XDG Base Directory Specification for info.")
 
     assert isinstance(old_confpath, unicode) or old_confpath is None


### PR DESCRIPTION
Addresses issue #65 and also tweaks wording a bit to better reflect what conforming to the XDG basedir spec means.

I personally am okay with such a message being info, because I like putting my stuff in $XDG_{CONFIG,DATA}_HOME whenever possible and in theory this message would have told me that I could move mypaint configs into those directories (in practice it got buried in GTK warning messages).

This is outside the scope of this issue, but it also wouldn't hurt to add something to a README about what needs to move where if you want to migrate to $XDG_{CONFIG,DATA}_HOME.