### PR TITLE
Fix the "NameError: global name 'lib' is not defined" error from pixbuf.py

### DIFF
--- a/lib/pixbuf.py
+++ b/lib/pixbuf.py
@@ -73,7 +73,7 @@ def load_from_file(filename, feedback_cb=None):
     :returns: the loaded pixbuf
     """
     fp = open(filename, 'rb')
-    pixbuf = lib.pixbuf.load_from_stream(fp, feedback_cb)
+    pixbuf = load_from_stream(fp, feedback_cb)
     fp.close()
     return pixbuf
 


### PR DESCRIPTION
Prevent the following bug when opening any file : 

```
Traceback (most recent call last):
  File "/usr/local/share/mypaint/gui/filehandling.py", line 446, in open_cb
    self.open_file(dialog.get_filename().decode('utf-8'))
  File "/usr/local/share/mypaint/gui/drawwindow.py", line 79, in wrapper
    func(self, *args, **kwargs)
  File "/usr/local/share/mypaint/gui/filehandling.py", line 264, in open_file
    self.doc.model.load(filename, feedback_cb=self.gtk_main_tick)
  File "/usr/local/share/mypaint/lib/document.py", line 764, in load
    load(filename, **kwargs)
  File "/usr/local/share/mypaint/lib/document.py", line 823, in load_from_pixbuf_file
    pixbuf = lib.pixbuf.load_from_file(filename, feedback_cb)
  File "/usr/local/share/mypaint/lib/pixbuf.py", line 76, in load_from_file
    pixbuf = lib.pixbuf.load_from_stream(fp, feedback_cb)
NameError: global name 'lib' is not defined
```