### PR TITLE
Use localized strings for key bindings in prefs dialog

### DIFF
--- a/gui/document.py
+++ b/gui/document.py
@@ -742,7 +742,7 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
                     continue
             # Don't repeat what's currently held
             pmods = pmods & ~mods
-            label = gui.buttonmap.button_press_displayname(button, pmods)
+            label = gui.buttonmap.button_press_displayname(button, pmods, True)
             mode_class = gui.mode.ModeRegistry.get_mode_class(action_name)
             mode_desc = None
             if mode_class:


### PR DESCRIPTION
This should fix issue #146.

Tested saving preferences, adding new shortcuts, removing existing shortcuts and the shortcut cheatsheet thing that appears in the bottom right corner of the window ("With Ctrl held down...").

Spun up mypaint with a french locale as well. Modifier keys (ctrl, alt, shift) are being translated by gtk.accelerator_get_label(). Button/Btn will need support in po/, but if strings like "Button1" already have a translation, then it should be pretty easy to do even if you don't speak the language in question.