### PR TITLE
Version Call in the Crash Log Change

### DIFF
--- a/gui/gtkexcepthook.py
+++ b/gui/gtkexcepthook.py
@@ -63,13 +63,15 @@ def analyse(exctyp, value, tb):
     import tokenize
     import keyword
     import platform
-    from lib.meta import MYPAINT_VERSION
+    import application
+
+    app = application.get_app()
 
     trace = StringIO()
     nlines = 3
     frecs = inspect.getinnerframes(tb, nlines)
 
-    trace.write('Mypaint version: %s\n' % MYPAINT_VERSION)
+    trace.write('Mypaint version: %s\n' % app.version)
     trace.write('System information: %s\n' % platform.platform())
 
     trace.write('Traceback (most recent call last):\n')


### PR DESCRIPTION
The version number in the crash log now includes the build date, and
the git version. This should make it easier to find out which git
versions are affecty by the reported issue.