### PR TITLE
Correctly handle PNG transparency when saving

### DIFF
--- a/gui/filehandling.py
+++ b/gui/filehandling.py
@@ -333,7 +333,7 @@ class FileHandler(object):
             recent_data.mime_type = mime_type
             recent_mgr.add_full(uri, recent_data)
         if not thumbnail_pixbuf:
-            options["background"] = not options.get("alpha", False)
+            options["render_background"] = not options.get("alpha", False)
             thumbnail_pixbuf = self.doc.model.render_thumbnail(**options)
         helpers.freedesktop_thumbnail(filename, thumbnail_pixbuf)
 

--- a/gui/filehandling.py
+++ b/gui/filehandling.py
@@ -12,6 +12,7 @@ from glob import glob
 import sys
 import logging
 logger = logging.getLogger(__name__)
+from collections import OrderedDict
 
 import glib
 import gtk
@@ -89,15 +90,25 @@ class FileHandler(object):
             (_("PNG (*.png)"), ("*.png",)),
             (_("JPEG (*.jpg; *.jpeg)"), ("*.jpg", "*.jpeg")),
         ]
-        self.saveformats = [
-            # (name, extension, options)
-            (_("By extension (prefer default format)"), None, {}),  # 0
-            (_("OpenRaster (*.ora)"), '.ora', {}),  # 1
-            (_("PNG solid with background (*.png)"), '.png', {'alpha': False}),  # 2
-            (_("PNG transparent (*.png)"), '.png', {'alpha': True}),  # 3
-            (_("Multiple PNG transparent (*.XXX.png)"), '.png', {'multifile': True}),  # 4
-            (_("JPEG 90% quality (*.jpg; *.jpeg)"), '.jpg', {'quality': 90}),  # 5
+        saveformat_keys = [
+            SAVE_FORMAT_ANY,
+            SAVE_FORMAT_ORA,
+            SAVE_FORMAT_PNGSOLID,
+            SAVE_FORMAT_PNGTRANS,
+            SAVE_FORMAT_PNGMULTI,
+            SAVE_FORMAT_JPEG,
+            SAVE_FORMAT_PNGDEFAULT,
         ]
+        saveformat_values = [
+            # (name, extension, options)
+            (_("By extension (prefer default format)"), None, {}),
+            (_("OpenRaster (*.ora)"), '.ora', {}),
+            (_("PNG solid with background (*.png)"), '.png', {'alpha': False}),
+            (_("PNG transparent (*.png)"), '.png', {'alpha': True}),
+            (_("Multiple PNG transparent (*.XXX.png)"), '.png', {'multifile': True}),
+            (_("JPEG 90% quality (*.jpg; *.jpeg)"), '.jpg', {'quality': 90}),
+        ]
+        self.saveformats = OrderedDict(zip(saveformat_keys, saveformat_values))
         self.ext2saveformat = {
             ".ora": (SAVE_FORMAT_ORA, "image/openraster"),
             ".png": (SAVE_FORMAT_PNGSOLID, "image/png"),
@@ -152,7 +163,7 @@ class FileHandler(object):
         label = gtk.Label(_('Format to save as:'))
         label.set_alignment(0.0, 0.0)
         combo = self.saveformat_combo = gtk.ComboBoxText()
-        for name, ext, opt in self.saveformats:
+        for name, ext, opt in self.saveformats.itervalues():
             combo.append_text(name)
         combo.set_active(0)
         combo.connect('changed', self.selected_save_format_changed_cb)

--- a/gui/filehandling.py
+++ b/gui/filehandling.py
@@ -31,6 +31,7 @@ SAVE_FORMAT_PNGSOLID = 2
 SAVE_FORMAT_PNGTRANS = 3
 SAVE_FORMAT_PNGMULTI = 4
 SAVE_FORMAT_JPEG = 5
+SAVE_FORMAT_PNGAUTO = 6
 
 
 # Utility function to work around the fact that gtk FileChooser/FileFilter
@@ -97,7 +98,6 @@ class FileHandler(object):
             SAVE_FORMAT_PNGTRANS,
             SAVE_FORMAT_PNGMULTI,
             SAVE_FORMAT_JPEG,
-            SAVE_FORMAT_PNGDEFAULT,
         ]
         saveformat_values = [
             # (name, extension, options)
@@ -111,7 +111,7 @@ class FileHandler(object):
         self.saveformats = OrderedDict(zip(saveformat_keys, saveformat_values))
         self.ext2saveformat = {
             ".ora": (SAVE_FORMAT_ORA, "image/openraster"),
-            ".png": (SAVE_FORMAT_PNGSOLID, "image/png"),
+            ".png": (SAVE_FORMAT_PNGAUTO, "image/png"),
             ".jpeg": (SAVE_FORMAT_JPEG, "image/jpeg"),
             ".jpg": (SAVE_FORMAT_JPEG, "image/jpeg"),
         }
@@ -557,8 +557,9 @@ class FileHandler(object):
                     else:
                         saveformat = default_saveformat
 
-                desc, ext_format, options = self.saveformats[saveformat]
-
+                # if saveformat isn't a key, it must be SAVE_FORMAT_PNGAUTO.
+                desc, ext_format, options = self.saveformats.get(saveformat,
+                    ("", ext, {'alpha': None}))
                 #
                 if ext:
                     if ext_format != ext:

--- a/lib/document.py
+++ b/lib/document.py
@@ -783,7 +783,7 @@ class Document (object):
                     time.time() - t0)
         return pixbuf
 
-    def save_png(self, filename, alpha=False, multifile=False, **kwargs):
+    def save_png(self, filename, alpha=None, multifile=False, **kwargs):
         """Save to one or more PNG files"""
         if multifile:
             self._save_multi_file_png(filename, **kwargs)
@@ -791,6 +791,8 @@ class Document (object):
             self._save_single_file_png(filename, alpha, **kwargs)
 
     def _save_single_file_png(self, filename, alpha, **kwargs):
+        if alpha is None:
+            alpha = not self.layer_stack.background_visible
         doc_bbox = self.get_effective_bbox()
         self.layer_stack.save_as_png(
             filename,

--- a/lib/document.py
+++ b/lib/document.py
@@ -560,7 +560,7 @@ class Document (object):
     ## Rendering tiles
 
     def blit_tile_into(self, dst, dst_has_alpha, tx, ty, mipmap_level=0,
-                       layers=None, background=None):
+                       layers=None, render_background=None):
         """Blit composited tiles into a destination surface"""
         self.layer_stack.blit_tile_into(
             dst, dst_has_alpha, tx, ty,
@@ -796,7 +796,7 @@ class Document (object):
             filename,
             *doc_bbox,
             alpha=alpha,
-            background=not alpha,
+            render_background=not alpha,
             **kwargs
         )
 

--- a/lib/layer.py
+++ b/lib/layer.py
@@ -3061,7 +3061,7 @@ class RootLayerStack (LayerStack):
             with dstsurf.tile_request(tx, ty, readonly=False) as dst:
                 self.composite_tile(
                     dst, True, tx, ty, mipmap_level=0,
-                    background=self._background_visible
+                    render_background=self._background_visible
                 )
                 if self._background_visible:
                     with bgsurf.tile_request(tx, ty, readonly=True) as bg:


### PR DESCRIPTION
For issue #165. The parameter that governed whether or not blit_tile_into() kept the background in or not was inconsistently named (it was 'background' in half the source code, and 'render_background' in the other half). I suspect the regression made its way in because it's...nontrivial to keep track of all the parameters weaving in and out of kwargs/options on the way from gui/filehandling.py to lib/fastpng.hpp.