### PR TITLE
fix for ora files without a default selected layer

### DIFF
--- a/lib/command.py
+++ b/lib/command.py
@@ -710,7 +710,7 @@ class SelectLayer (Command):
         super(SelectLayer, self).__init__(doc, **kwds)
         layers = self.doc.layer_stack
         self.path = layers.canonpath(index=index, path=path, layer=layer)
-        self.prev_path = layers.canonpath(path=layers.get_current_path())
+        self.prev_path = layers.canonpath(path=layers.get_current_path(),usecurrent=True)
 
     def redo(self):
         layers = self.doc.layer_stack

--- a/lib/layer.py
+++ b/lib/layer.py
@@ -2732,7 +2732,7 @@ class RootLayerStack (LayerStack):
         """
         if path is not None:
             layer = self.deepget(path)
-            if layer is self:
+            if layer is self and not usecurrent:
                 raise ValueError("path=%r is root: must be descendent" %
                                  (path,))
             if layer is not None:


### PR DESCRIPTION
i picked up an issue if i save ora files in krita, there is no default selected layer,
then when re-opening in mypaint and trying to select the layer it breaks, 

Traceback (most recent call last):
  File "/usr/local/share/mypaint/gui/layerswindow.py", line 469, in _view_button_press_cb
    docmodel.select_layer(path=click_layerpath)
  File "/usr/local/share/mypaint/lib/document.py", line 380, in select_layer
    self.do(command.SelectLayer(self, path=sel_path))
  File "/usr/local/share/mypaint/lib/command.py", line 715, in __init__
    self.prev_path = layers.canonpath(path=layers.get_current_path())
  File "/usr/local/share/mypaint/lib/layer.py", line 2642, in canonpath
    (path,))
ValueError: path=() is root: must be descendent
