### PR TITLE
Viewfinder style change

### DIFF
--- a/gui/drawutils.py
+++ b/gui/drawutils.py
@@ -431,11 +431,18 @@ def render_round_floating_color_chip(cr, x, y, color, radius):
 
 
 def draw_draggable_edge_drop_shadow(cr, p0, p1, width):
-    """Draw the drop shadown for an edge which can be dragged"""
-
-    cr.save()
+    """Draw the drop shadow for an edge which can be dragged, then clear the path"""
     x0, y0 = p0
     x1, y1 = p1
+    cr.move_to(x0, y0)
+    cr.line_to(x1, y1)
+    draw_draggable_path_drop_shadow(cr, width)
+    cr.new_path()
+
+def draw_draggable_path_drop_shadow(cr, width):
+    """Draw the drop shadow for all draggable edges in the current path, without clearing the current path"""
+
+    cr.save()
 
     # Drop shadow
     alpha = gui.style.DROP_SHADOW_ALPHA
@@ -447,14 +454,18 @@ def draw_draggable_edge_drop_shadow(cr, p0, p1, width):
     a = float(gui.style.DROP_SHADOW_ALPHA) / steps
     cr.set_source_rgba(0, 0, 0, a)
 
-    cr.move_to(x0+xoffs, y0+yoffs)
-    cr.line_to(x1+xoffs, y1+yoffs)
+    old_path = cr.copy_path()
+    cr.translate(xoffs, yoffs)
+    cr.new_path()
+    cr.append_path(old_path)
     steps = int(math.ceil(blur * 2))
     for i in range(steps):  # [0...4]
         b = blur * float(i+1) / steps
         cr.set_line_width(width + b)
         cr.stroke_preserve()
+    cr.translate(-xoffs, -yoffs)
     cr.new_path()
+    cr.append_path(old_path)
     cr.restore()
 
 


### PR DESCRIPTION
![new_viewfinder](https://cloud.githubusercontent.com/assets/4390573/6215123/cf7ac83a-b5cb-11e4-86cb-848087d7cd89.png)

I was a bit concerned about what the cairo path juggling in the new `draw_draggable_path_drop_shadow()` would mean for performance, though it doesn't seem noticeably slower on my machine.

The extra `math.ceil` calls are there because there are occasional rendering artifacts without them. I'm not really sure what they actually fix, since I thought that rounding protection was what the `+ 4` was for.

I also wanted to have a chat about when/if the viewfinder frame should change colour. I think it makes sense to have it turn the active colour (yellow) when it's hovered over and while it's being dragged. But what about when a user is zooming/rotating through the canvas?