### PR TITLE
Use native cache directories for thumbnails in Linux and Mac OS X

### DIFF
--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -148,7 +148,7 @@ def gdkpixbuf2numpy(pixbuf):
 
 
 def freedesktop_thumbnail(filename, pixbuf=None):
-    """Fetch or (re-)generate the thumbnail in ~/.thumbnails.
+    """Fetch or (re-)generate the thumbnail in $XDG_CACHE_HOME/thumbnails.
 
     If there is no thumbnail for the specified filename, a new
     thumbnail will be generated and stored according to the FDO spec.
@@ -167,11 +167,8 @@ def freedesktop_thumbnail(filename, pixbuf=None):
     logger.debug("thumb: uri=%r", uri)
     file_hash = hashlib.md5(uri).hexdigest()
 
-    if sys.platform == 'win32':
-        base_directory = os.path.join(GLib.get_user_data_dir().decode('utf-8'),
-                                      'mypaint', 'thumbnails')
-    else:
-        base_directory = expanduser_unicode(u'~/.thumbnails')
+    base_directory = os.path.join(GLib.get_user_cache_dir().decode('utf-8'),
+                                  'thumbnails')
 
     directory = os.path.join(base_directory, 'normal')
     tb_filename_normal = os.path.join(directory, file_hash) + '.png'


### PR DESCRIPTION
I don't usually have access to any OSX machines, so it'd be cool if someone with a Mac tested this out. Naming the directory 'MyPaint' seems to blend in better, but may cause headaches down the road. I can change that to 'mypaint' if it seems like it would cause too much trouble.

As for the Linux-y changes...how many applications actually use `~/.thumbnails` these days? Does anybody actually prefer using it to following the thumbnail spec? Is it better to just create `$XDG_CACHE_HOME/thumbnails` or `~/.cache/thumbnails` if needed?