### PR TITLE
Do not deselect movement tools after one use

### DIFF
--- a/gui/colorpicker.py
+++ b/gui/colorpicker.py
@@ -74,7 +74,7 @@ class ColorPickMode (gui.mode.OneshotDragMode):
         return _(u"Set the color used for painting")
 
     def __init__(self, **kwds):
-        super(ColorPickMode, self).__init__(**kwds)
+        super(ColorPickMode, self).__init__(unmodified_persist=False, **kwds)
         self._overlay = None
         self._started_from_key_press = self.ignore_modifiers
         self._start_drag_on_next_motion_event = False

--- a/gui/document.py
+++ b/gui/document.py
@@ -663,7 +663,10 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
         if handler_type == 'mode_class':
             # Transfer control to another mode temporarily.
             assert issubclass(handler, gui.mode.DragMode)
-            mode = handler()
+            if issubclass(handler, gui.mode.OneshotDragMode):
+                mode = handler(temporary_activation=True)
+            else:
+                mode = handler()
             self.modes.push(mode)
             if win is not None:
                 return mode.key_press_cb(win, tdw, event)
@@ -1762,7 +1765,10 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
             self.modes.pop()
             flip_action.keyup_callback = lambda *a: None  # suppress repeats
         else:
-            mode = mode_class(ignore_modifiers=True)
+            if issubclass(mode_class, gui.mode.OneshotDragMode):
+                mode = mode_class(ignore_modifiers=True, temporary_activation=False)
+            else:
+                mode = mode_class(ignore_modifiers=True)
             if flip_action.keydown:
                 flip_action.__pressed = True
                 # Change what happens on a key-up after a short while.
@@ -1829,7 +1835,10 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
             return
 
         if self.modes.top.__class__ is not mode_class:
-            mode = mode_class()
+            if issubclass(mode_class, gui.mode.OneshotDragMode):
+                mode = mode_class(temporary_activation=False)
+            else:
+                mode = mode_class()
             self.modes.context_push(mode)
 
     def _modestack_changed_cb(self, modestack, old, new):

--- a/gui/layermanip.py
+++ b/gui/layermanip.py
@@ -25,7 +25,7 @@ from gettext import gettext as _
 
 
 class LayerMoveMode (gui.mode.ScrollableModeMixin,
-                     gui.mode.DragMode):
+                     gui.mode.OneshotDragMode):
     """Moving a layer interactively
 
     MyPaint is tile-based, and tiles must align between layers.
@@ -69,7 +69,6 @@ class LayerMoveMode (gui.mode.ScrollableModeMixin,
             cursor_name,
         )
 
-    unmodified_persist = True
     permitted_switch_actions = set([
         'RotateViewMode',
         'ZoomViewMode',
@@ -211,5 +210,5 @@ class LayerMoveMode (gui.mode.ScrollableModeMixin,
             if self.initial_modifiers:
                 if (self.final_modifiers & self.initial_modifiers) == 0:
                     self.doc.modes.pop()
-            else:
+            elif self.temporary_activation:
                 self.doc.modes.pop()

--- a/gui/mode.py
+++ b/gui/mode.py
@@ -935,7 +935,7 @@ class DragMode (InteractionMode):
                     # This mode started with modifiers held
                     modifiers = self.current_modifiers()
                     if (modifiers & old_modifiers) == 0:
-                        # But nonee of them are held any more,
+                        # But none of them are held any more,
                         # so queue a further pop.
                         gobject.idle_add(self.__pop_modestack_idle_cb)
             else:
@@ -1039,10 +1039,19 @@ class OneshotDragMode (DragMode):
     These are utility modes which allow the user to do quick, simple
     tasks with the canvas like pick a color from it or pan the view.
     """
+    def __init__(self, unmodified_persist=True, temporary_activation=True, **kwargs):
+        """
+        :param bool unmodified_persist: Stay active if entered without modkeys
+        :param bool \*\*kwargs: Passed through to other __init__s.
 
-    #: If true, and spring-loaded, stay active if no modifiers were
-    #: held initially.
-    unmodified_persist = False
+        If unmodified_persist is true, and drag mode is spring-loaded, the
+        tool will stay active if no modifiers were held initially. This means
+        tools will not deselect themselves after one use if activated from,
+        say, the toolbar.
+        """
+        DragMode.__init__(self)
+        self.unmodified_persist = unmodified_persist
+        self.temporary_activation = temporary_activation
 
     def stackable_on(self, mode):
         """Oneshot modes return to the mode the user came from on exit"""
@@ -1065,7 +1074,7 @@ class OneshotDragMode (DragMode):
                     self.doc.modes.pop()
         else:
             # No modifiers were held when this mode was entered.
-            if not self.unmodified_persist:
+            if self.temporary_activation or (not self.unmodified_persist):
                 if self is self.doc.modes.top:
                     self.doc.modes.pop()
         return super(OneshotDragMode, self).drag_stop_cb(tdw)

--- a/gui/viewmanip.py
+++ b/gui/viewmanip.py
@@ -21,13 +21,18 @@ from gettext import gettext as _
 ## Class defs
 
 class PanViewMode (gui.mode.OneshotDragMode):
-    """A oneshot mode for translating the viewport by dragging."""
+    """A mode for translating the viewport by dragging."""
 
     ACTION_NAME = 'PanViewMode'
 
     pointer_behavior = gui.mode.Behavior.CHANGE_VIEW
     scroll_behavior = gui.mode.Behavior.NONE  # XXX grabs ptr, so no CHANGE_VIEW
-    supports_button_switching = False
+    supports_button_switching = True
+
+    permitted_switch_actions = set([
+        'RotateViewMode',
+        'ZoomViewMode'
+    ] + gui.mode.BUTTON_BINDING_ACTIONS)
 
     @classmethod
     def get_name(cls):
@@ -53,13 +58,18 @@ class PanViewMode (gui.mode.OneshotDragMode):
 
 
 class ZoomViewMode (gui.mode.OneshotDragMode):
-    """A oneshot mode for zooming the viewport by dragging."""
+    """A mode for zooming the viewport by dragging."""
 
     ACTION_NAME = 'ZoomViewMode'
 
     pointer_behavior = gui.mode.Behavior.CHANGE_VIEW
     scroll_behavior = gui.mode.Behavior.NONE  # XXX grabs ptr, so no CHANGE_VIEW
-    supports_button_switching = False
+    supports_button_switching = True
+
+    permitted_switch_actions = set([
+        'PanViewMode'
+        'RotateViewMode',
+    ] + gui.mode.BUTTON_BINDING_ACTIONS)
 
     @classmethod
     def get_name(cls):
@@ -88,13 +98,18 @@ class ZoomViewMode (gui.mode.OneshotDragMode):
 
 
 class RotateViewMode (gui.mode.OneshotDragMode):
-    """A oneshot mode for rotating the viewport by dragging."""
+    """A mode for rotating the viewport by dragging."""
 
     ACTION_NAME = 'RotateViewMode'
 
     pointer_behavior = gui.mode.Behavior.CHANGE_VIEW
     scroll_behavior = gui.mode.Behavior.NONE  # XXX grabs ptr, so no CHANGE_VIEW
-    supports_button_switching = False
+    supports_button_switching = True
+
+    permitted_switch_actions = set([
+        'PanViewMode'
+        'ZoomViewMode',
+    ] + gui.mode.BUTTON_BINDING_ACTIONS)
 
     @classmethod
     def get_name(cls):

--- a/gui/viewmanip.py
+++ b/gui/viewmanip.py
@@ -20,13 +20,13 @@ from gettext import gettext as _
 
 ## Class defs
 
-class PanViewMode (gui.mode.OneshotDragMode):
+class PanViewMode (gui.mode.ScrollableModeMixin, gui.mode.OneshotDragMode):
     """A mode for translating the viewport by dragging."""
 
     ACTION_NAME = 'PanViewMode'
 
     pointer_behavior = gui.mode.Behavior.CHANGE_VIEW
-    scroll_behavior = gui.mode.Behavior.NONE  # XXX grabs ptr, so no CHANGE_VIEW
+    scroll_behavior = gui.mode.Behavior.CHANGE_VIEW
     supports_button_switching = True
 
     permitted_switch_actions = set([
@@ -57,13 +57,13 @@ class PanViewMode (gui.mode.OneshotDragMode):
         super(PanViewMode, self).drag_update_cb(tdw, event, dx, dy)
 
 
-class ZoomViewMode (gui.mode.OneshotDragMode):
+class ZoomViewMode (gui.mode.ScrollableModeMixin, gui.mode.OneshotDragMode):
     """A mode for zooming the viewport by dragging."""
 
     ACTION_NAME = 'ZoomViewMode'
 
     pointer_behavior = gui.mode.Behavior.CHANGE_VIEW
-    scroll_behavior = gui.mode.Behavior.NONE  # XXX grabs ptr, so no CHANGE_VIEW
+    scroll_behavior = gui.mode.Behavior.CHANGE_VIEW
     supports_button_switching = True
 
     permitted_switch_actions = set([
@@ -97,13 +97,13 @@ class ZoomViewMode (gui.mode.OneshotDragMode):
         super(ZoomViewMode, self).drag_update_cb(tdw, event, dx, dy)
 
 
-class RotateViewMode (gui.mode.OneshotDragMode):
+class RotateViewMode (gui.mode.ScrollableModeMixin, gui.mode.OneshotDragMode):
     """A mode for rotating the viewport by dragging."""
 
     ACTION_NAME = 'RotateViewMode'
 
     pointer_behavior = gui.mode.Behavior.CHANGE_VIEW
-    scroll_behavior = gui.mode.Behavior.NONE  # XXX grabs ptr, so no CHANGE_VIEW
+    scroll_behavior = gui.mode.Behavior.CHANGE_VIEW
     supports_button_switching = True
 
     permitted_switch_actions = set([


### PR DESCRIPTION
Where "movement tools" means Move Layer, Pan View, Zoom View or Rotate
View modes. Addresses mypaint/mypaint#87.

Allow the popup menu to be brought up while in the above three modes

Fix a small typo in a comment in gui/mode.py