### PR TITLE
Add right click menu to brushes

### DIFF
--- a/gui/brushmanager.py
+++ b/gui/brushmanager.py
@@ -838,7 +838,7 @@ class BrushManager (object):
         :param group: Name of the group to delete
         :type group: str
 
-        Oprhaned brushes will be placed into `DELETED_BRUSH_GROUP`, which
+        Orphaned brushes will be placed into `DELETED_BRUSH_GROUP`, which
         will be created if necessary.
 
         """

--- a/gui/brushmanager.py
+++ b/gui/brushmanager.py
@@ -38,7 +38,7 @@ PREVIEW_H = 128   #: Height of brush preview images
 
 FOUND_BRUSHES_GROUP = 'lost&found'   #: Orphaned brushes found at startup
 DELETED_BRUSH_GROUP = 'deleted'   #: Orphaned brushes go here after group del
-FAVORITES_BRUSH_GROUP = 'favorites'  #: User's favourites
+FAVORITES_BRUSH_GROUP = u'favorites'  #: User's favourites
 NEW_BRUSH_GROUP = 'new'  #: Home for newly created brushes
 
 ## Internal module constants

--- a/gui/brushselectionwindow.py
+++ b/gui/brushselectionwindow.py
@@ -173,17 +173,19 @@ class BrushPopupMenu(gtk.Menu):
             item.connect("activate", BrushPopupMenu.unfavorite_cb, bl, brush)
             self.append(item)
 
-        item = gtk.MenuItem(_("Clone"))
-        item.connect("activate", BrushPopupMenu.clone_cb, bl, brush)
-        self.append(item)
+        if bl.group != brushmanager.FAVORITES_BRUSH_GROUP:
+            item = gtk.MenuItem(_("Clone"))
+            item.connect("activate", BrushPopupMenu.clone_cb, bl, brush)
+            self.append(item)
 
         item = gtk.MenuItem(_("Edit brush settings"))
         item.connect("activate", BrushPopupMenu.edit_cb, bl, brush)
         self.append(item)
 
-        item = gtk.MenuItem(_("Delete"))
-        item.connect("activate", BrushPopupMenu.delete_cb, bl, brush)
-        self.append(item)
+        if bl.group != brushmanager.FAVORITES_BRUSH_GROUP:
+            item = gtk.MenuItem(_("Delete"))
+            item.connect("activate", BrushPopupMenu.delete_cb, bl, brush, self)
+            self.append(item)
 
     @staticmethod
     def favorite_cb(menuitem, bl, brush):
@@ -218,8 +220,12 @@ class BrushPopupMenu(gtk.Menu):
         BrushEditorWindow().show()
 
     @staticmethod
-    def delete_cb(menuitem, bl, brush):
+    def delete_cb(menuitem, bl, brush, menu):
+        if not dialogs.confirm(menu, _("Really delete brush from disk?")):
+            return
         bl.remove_brush(brush)
+        faves = bl.bm.groups[brushmanager.FAVORITES_BRUSH_GROUP]
+        bl.bm.brushes_changed(faves)
 
 
 class BrushGroupTool (SizedVBoxToolWidget):

--- a/gui/brushselectionwindow.py
+++ b/gui/brushselectionwindow.py
@@ -34,6 +34,7 @@ from libmypaint import brushsettings
 import pixbuflist
 import dialogs
 import brushmanager
+from brusheditor import BrushEditorWindow
 from lib.helpers import escape
 from workspace import SizedVBoxToolWidget
 import widgets
@@ -70,6 +71,7 @@ class BrushList (pixbuflist.PixbufList):
         self.bm.brushes_changed += self.brushes_modified_cb
         self.bm.brush_selected += self.brush_selected_cb
         self.item_selected += self._item_selected_cb
+        self.item_popup += self._item_popup_cb
 
     def do_get_request_mode(self):
         return gtk.SizeRequestMode.HEIGHT_FOR_WIDTH
@@ -149,6 +151,75 @@ class BrushList (pixbuflist.PixbufList):
             for brushes in self.bm.groups.itervalues():
                 self.bm.brushes_changed(brushes)
         self.bm.select_brush(brush)
+
+    def _item_popup_cb(self, self_, brush):
+        time = gtk.get_current_event_time()
+        self.menu = BrushPopupMenu(self, brush)
+        self.menu.show_all()
+        self.menu.popup(parent_menu_shell=None, parent_menu_item=None,
+            func=None, button=3, activate_time=time, data=None)
+
+
+class BrushPopupMenu(gtk.Menu):
+    def __init__(self, bl, brush):
+        super(BrushPopupMenu, self).__init__()
+        faves = bl.bm.groups[brushmanager.FAVORITES_BRUSH_GROUP]
+        if brush not in faves:
+            item = gtk.MenuItem(_("Add to favorites"))
+            item.connect("activate", BrushPopupMenu.favorite_cb, bl, brush)
+            self.append(item)
+        else:
+            item = gtk.MenuItem(_("Remove from favorites"))
+            item.connect("activate", BrushPopupMenu.unfavorite_cb, bl, brush)
+            self.append(item)
+
+        item = gtk.MenuItem(_("Clone"))
+        item.connect("activate", BrushPopupMenu.clone_cb, bl, brush)
+        self.append(item)
+
+        item = gtk.MenuItem(_("Edit brush settings"))
+        item.connect("activate", BrushPopupMenu.edit_cb, bl, brush)
+        self.append(item)
+
+        item = gtk.MenuItem(_("Delete"))
+        item.connect("activate", BrushPopupMenu.delete_cb, bl, brush)
+        self.append(item)
+
+    @staticmethod
+    def favorite_cb(menuitem, bl, brush):
+        faves = bl.bm.groups[brushmanager.FAVORITES_BRUSH_GROUP]
+        if brush not in faves:
+            faves.append(brush)
+        bl.bm.brushes_changed(faves)
+        bl.bm.save_brushorder()
+
+    @staticmethod
+    def unfavorite_cb(menuitem, bl, brush):
+        faves = bl.bm.groups[brushmanager.FAVORITES_BRUSH_GROUP]
+        try:
+            faves.remove(brush)
+        except ValueError:
+            return
+        bl.bm.brushes_changed(faves)
+        bl.bm.save_brushorder()
+
+    @staticmethod
+    def clone_cb(menuitem, bl, brush):
+        new_name = brush.name + "copy"
+        brush_copy = brush.clone(new_name)
+        index = bl.brushes.index(brush) + 1
+        bl.insert_brush(index, brush_copy)
+        brush_copy.save()
+        bl.bm.save_brushorder()
+
+    @staticmethod
+    def edit_cb(menuitem, bl, brush):
+        bl.bm.select_brush(brush)
+        BrushEditorWindow().show()
+
+    @staticmethod
+    def delete_cb(menuitem, bl, brush):
+        bl.remove_brush(brush)
 
 
 class BrushGroupTool (SizedVBoxToolWidget):

--- a/gui/pixbuflist.py
+++ b/gui/pixbuflist.py
@@ -306,16 +306,24 @@ class PixbufList(gtk.DrawingArea):
         if i >= len(self.itemlist):
             return
         item = self.itemlist[i]
-        self.set_selected(item)
-        self.item_selected(item)
-        if self.selected is not None:
-            # early exception if drag&drop would break
-            assert self.selected in self.itemlist, 'selection failed: the user selected %r by pointing at it, but after calling item_selected() %r is active instead!' % (item, self.selected)
-        self.in_potential_drag = True
+        if (event.button == 3):
+            self.set_selected(item)
+            self.item_popup(item)
+        else:
+            self.set_selected(item)
+            self.item_selected(item)
+            if self.selected is not None:
+                # early exception if drag&drop would break
+                assert self.selected in self.itemlist, 'selection failed: the user selected %r by pointing at it, but after calling item_selected() %r is active instead!' % (item, self.selected)
+            self.in_potential_drag = True
 
     @event
     def item_selected(self, item):
         """Event: the user selected an item in the list"""
+
+    @event
+    def item_popup(self, item):
+        """Event: the user brought up the popup menu for an item in the list"""
 
     def button_release_cb(self, widget, event):
         self.in_potential_drag = False

--- a/gui/toolbar.py
+++ b/gui/toolbar.py
@@ -301,7 +301,7 @@ class BrushDropdownToolItem (gtk.ToolItem):
         section_frame.add(section_vbox)
 
         chooser = dialogs.QuickBrushChooser(app)
-        chooser.brush_selected += self._brushchooser_brush_selected_cb
+        chooser.bm.brush_selected += self._brushchooser_brush_selected_cb
         evbox = gtk.EventBox()
         evbox.add(chooser)
         section_vbox.pack_start(evbox, True, True)
@@ -331,7 +331,7 @@ class BrushDropdownToolItem (gtk.ToolItem):
     def _history_button_clicked_cb(self, view):
         self.dropdown_button.panel_hide()
 
-    def _brushchooser_brush_selected_cb(self, chooser, brush):
+    def _brushchooser_brush_selected_cb(self, bm, brush, brushinfo):
         self.dropdown_button.panel_hide(immediate=False)
         self.app.brushmanager.select_brush(brush)
 


### PR DESCRIPTION
Starting with add to favourites, remove from favourites, copy, delete
and a placeholder for edit. I also noticed that the recently used list in the toolbar window doesn't respond to right clicks.

![menu](https://cloud.githubusercontent.com/assets/4390573/6515388/65ae6a8a-c357-11e4-8cca-2c8ff7844a99.png)

This is a WIP that needs more testing. **use a separate throwaway config area for this. It was eating brush groups every launch until I fixed something, and I'm not totally convinced the code is bulletproof yet.**

Partial list of things that I've tried:
* copy brush, restart mypaint
* copy brush, copy its copy, restart mypaint
* copy brush, switch group, switch back, delete copy, restart mypaint
* delete brush, restart mypaint
* favourite brush, restart mypaint
* copy brush, favourite copy, delete copy, restart mypaint

Also would appreciate feedback on the naming of the menu options.

Addresses issue #229 .