### PR TITLE
removed an optimization causing a loss of data when exporting as png

### DIFF
--- a/lib/tiledsurface.py
+++ b/lib/tiledsurface.py
@@ -506,8 +506,6 @@ class MyPaintSurface (object):
         if 'alpha' not in kwargs:
             kwargs['alpha'] = True
 
-        if len(self.tiledict) == 1:
-            kwargs['single_tile_pattern'] = True
         pixbufsurface.save_as_png(self, filename, *args, **kwargs)
 
     def get_tiles(self):


### PR DESCRIPTION
If a layer contains really few strokes (like a single short line), when exporting as multiple png, this layer's png will be empty.

Repro steps:
1: create a new document.
2: activate the Frame to have a finite canvas size.
3: draw a short line in the middle of the canvas.
4: export as multiple png.
5: notice the png corresponding to your layer is empty.