### PR TITLE
Better crash dialog

### DIFF
--- a/gui/gtkexcepthook.py
+++ b/gui/gtkexcepthook.py
@@ -176,7 +176,7 @@ def _info(exctyp, value, tb):
     textview = gtk.TextView()
     textview.show()
     textview.set_editable(False)
-    textview.modify_font(pango.FontDescription("Monospace").set_size(14))
+    textview.modify_font(pango.FontDescription("Monospace normal"))
 
     sw = gtk.ScrolledWindow()
     sw.show()


### PR DESCRIPTION
I guess the new buttons could also go right above details (and would probably help with the peculiar linewrapping), but I feel like that's maybe kind of weird for a dialog window.

It looks like someone intended the trace to be printed out in monospace, but it wasn't doing that for me. Fixed for me now, though I can't tell if I've now broken it for other versions of...pygtk? pango?

A first stab at #232.