### PR TITLE
Found the tooltips applied to the wrong places in HSV Square

### DIFF
--- a/gui/colors/hsvsquare.py
+++ b/gui/colors/hsvsquare.py
@@ -126,8 +126,8 @@ class HSVSquare(gtk.VBox, ColorAdjuster):
         self.__slider.set_color_manager(manager)
 
     def _update_tooltips(self):
-        self.__slice.set_tooltip_text(_("HSV Hue"))
-        self.__slider.set_tooltip_text(_("HSV Saturation and Value"))
+        self.__slider.set_tooltip_text(_("HSV Hue"))
+        self.__slice.set_tooltip_text(_("HSV Saturation and Value"))
 
 class HSVCubeSlider (HueSaturationWheelAdjuster):
     """Concrete base class for hue/saturation wheels, indep. of color space.


### PR DESCRIPTION
This one's just a minor fix for swapping the tooltip labels around in HSV Square. ^^;