### PR TITLE
Properly emulate old scrolling functionality

### DIFF
--- a/gui/mode.py
+++ b/gui/mode.py
@@ -473,12 +473,10 @@ class ScrollableModeMixin (InteractionMode):
                 if constrain_smooth:
                     # Needs to work in an identical fashion to old-style
                     # zooming.
-                    while self.__total_dy > 1:
-                        self.__total_dy -= 1.0
-                        doc.zoom(doc.ZOOM_OUTWARDS)
-                    while self.__total_dy < -1:
-                        self.__total_dy += 1.0
+                    if direction == gdk.SCROLL_UP:
                         doc.zoom(doc.ZOOM_INWARDS)
+                    elif direction == gdk.SCROLL_DOWN:
+                        doc.zoom(doc.ZOOM_OUTWARDS)
                 else:
                     # Smooth scroll zooming is intended to resemble what
                     # gui.viewmanip.ZoomViewMode does, minus the


### PR DESCRIPTION
The logic for the old step-wise scrolling functionality was improporly recreated in the new smooth-scrolling-based logic as of 189e195. This makes it *exactly* the same as it was before.

I'm not familiar with this code so there might be some subtleties I'm missing that have to be accounted for, in which case just tell me and I'll fix it.

Right now it seems that this is only used if you untick the "Handle smooth scrolling events when devices send them" in your preferences, so I think there's still problems with the code not properly figuring out what's actually a smooth scrolling event.