### PR TITLE
Restore old color picker behaviour (hover to pick)

### DIFF
--- a/gui/colorpicker.py
+++ b/gui/colorpicker.py
@@ -73,10 +73,10 @@ class ColorPickMode (gui.mode.OneshotDragMode):
     def get_usage(self):
         return _(u"Set the color used for painting")
 
-    def __init__(self, **kwds):
-        super(ColorPickMode, self).__init__(unmodified_persist=False, **kwds)
+    def __init__(self, ignore_modifiers=False, **kwds):
+        super(ColorPickMode, self).__init__(**kwds)
         self._overlay = None
-        self._started_from_key_press = self.ignore_modifiers
+        self._started_from_key_press = ignore_modifiers
         self._start_drag_on_next_motion_event = False
 
     def enter(self, doc, **kwds):


### PR DESCRIPTION
In older versions of mypaint, it was possible to pick a color by simply
holding down the 'pick color' hotkey and hovering over a color. At some
point, this changed. Users were now required to hold down the hotkey and
then drag over the color. This patch restores the old behaviour.

Resolves mypaint/mypaint#253.