### PR TITLE
Make floating windows process keyboard events

### DIFF
--- a/gui/workspace.py
+++ b/gui/workspace.py
@@ -1848,6 +1848,8 @@ class ToolStackWindow (Gtk.Window):
             win.set_decorations(decor)
             wmfuncs = Gdk.WMFunction.RESIZE | Gdk.WMFunction.MOVE
             win.set_functions(wmfuncs)
+            self.connect('key-press-event', toplevel.key_press_event_cb)
+            self.connect('key-release-event', toplevel.key_release_event_cb)
         # Hack to force an initial x,y position to be what was saved, used
         # as a workaround for WM bugs and misfeatures.
         # Forcing the position up front rather than in an idle handler


### PR DESCRIPTION
Before this patch, some events were only processed if sent to the main
drawing window. Keyboard events sent to floating windows were silently
ignored. This caused strange behaviour when trying to pan a detached
scratchpad using spacebar + mouse drag.

Resolves mypaint/mypaint#244.