### PR TITLE
Dispatch mode-flip actions to the active document

### DIFF
--- a/gui/document.py
+++ b/gui/document.py
@@ -1810,6 +1810,11 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
         when entered.  See also: `gui.mode.DragMode`.
 
         """
+        # If this is not the active document, dispatch the action to it.
+        active_doc = Document.get_active_instance()
+        if active_doc != self:
+            return active_doc.mode_flip_action_activated_cb(flip_action)
+
         flip_action_name = flip_action.get_name()
         assert flip_action_name.startswith("Flip")
         # Find the corresponding gtk.RadioAction


### PR DESCRIPTION
All mode-flip actions are currently being sent to the main document. This
causes issues such as mypaint/mypaint#272. It also makes it impossible to
use other tools (such as line-drawing tools) on the scratchpad. With this
patch, mode-flip actions are sent to the active document instead.

Note that this does not completely solve issue mypaint/mypaint#272, since
it is still impossible to use the eyedropper on the scratchpad by clicking on
the toolbar.