### PR TITLE
When the user defines a shortcut, always inform Gtk.AccelMap that the…

### DIFF
--- a/gui/accelmap.py
+++ b/gui/accelmap.py
@@ -476,16 +476,11 @@ class AccelMapEditor (Gtk.Grid):
     def _set_accelmap_entry(cls, path, keyval, mods):
         cls._delete_clashing_accelmap_entries(keyval, mods, path)
         accel_name = Gtk.accelerator_name(keyval, mods)
-        entry_exists, junk = Gtk.AccelMap.lookup_entry(path)
-        if entry_exists:
-            logger.info("Changing entry %r: %r", accel_name, path)
-            if Gtk.AccelMap.change_entry(path, keyval, mods, True):
-                logger.debug("Updated %r successfully", path)
-            else:
-                logger.error("Failed to update %r", path)
+        logger.info("Changing entry %r: %r", accel_name, path)
+        if Gtk.AccelMap.change_entry(path, keyval, mods, True):
+            logger.debug("Updated %r successfully", path)
         else:
-            logger.info("Adding new entry %r: %r", accel_name, path)
-            Gtk.AccelMap.add_entry(path, keyval, mods)
+            logger.error("Failed to update %r", path)
         entry_exists, junk = Gtk.AccelMap.lookup_entry(path)
         assert entry_exists
 


### PR DESCRIPTION
… binding is being overriden, not initialized.

This helps bindings survive restarts regardless of whether the corresponding action is present in the menus or not.
Fixes #497.

I don't know why was this conditional here in the first place, though. Might want to audit before merging.


