### PR TITLE
Check for use_sharedlib before building lib tests

### DIFF
--- a/lib/SConscript
+++ b/lib/SConscript
@@ -20,9 +20,15 @@ def build_py_module(env, *args, **kwargs):
 
 
 # Build against brushlib
-env.Prepend(LIBS=['mypaint-tests', "mypaint"])
+if env['use_sharedlib']:
+    env.Prepend(LIBS=["mypaint"])
+else:
+    env.Prepend(LIBS=['mypaint-tests', "mypaint"])
 env.Append(LIBPATH="../brushlib")
-env.Append(CPPPATH=['../brushlib', '../brushlib/tests'])
+if env['use_sharedlib']:
+    env.Append(CPPPATH=['../brushlib'])
+else:
+    env.Append(CPPPATH=['../brushlib', '../brushlib/tests'])
 
 
 def parse_pkg_config(env, libname):
@@ -199,10 +205,17 @@ if 'NDEBUG' in env.get('CPPDEFINES', []):
 if env['debug']:
     env.Append(CCFLAGS='-O0', LINKFLAGS='-O0')
 
+#If we're building against the shared lib, omit test code
+if env['use_sharedlib']:
+    env.Append(CCFLAGS='-DNO_TESTS')
 
 # python extension module
-
 env.Append(SWIGFLAGS="-Wall -noproxydel -python -c++")
+
+#If we're building against the shared lib, omit test code
+if env['use_sharedlib']:
+    env.Append(SWIGFLAGS='-DNO_TESTS')
+
 #env.Append(SWIGCXXFILESUFFIX="_wrap.cpp") #No: SCons 2.3.1 removes ".ext" (!)
 module_src = [
         'mypaintlib.i',

--- a/lib/tiledsurface.hpp
+++ b/lib/tiledsurface.hpp
@@ -8,7 +8,9 @@
  */
 
 #include <mypaint-tiled-surface.h>
+#ifndef NO_TESTS
 #include <mypaint-test-surface.h>
+#endif
 
 static const int TILE_SIZE = MYPAINT_TILE_SIZE;
 static const int MAX_MIPMAP_LEVEL = MYPAINT_MAX_MIPMAP_LEVEL;
@@ -150,6 +152,7 @@ mypaint_python_surface_factory(gpointer user_data)
 
 } // extern "C"
 
+#ifndef NO_TESTS
 int
 run_brushlib_tests(void)
 {
@@ -160,3 +163,4 @@ run_brushlib_tests(void)
 
     return retval;
 }
+#endif


### PR DESCRIPTION
Addressed #539

Prior to this, it would be impossible to run mypaint without the tests
from brushlib. This shouldn't break the Travis build since it doesn't
set use_sharedlib=true. It surrounds the relevant test code with
ifndef's that check for the presence of NO_TESTS passed from g++ via scons. If
NO_TESTS is defined, then lib/ avoids building any test related code.

It maybe a better idea to define the test building as separate from checking the presence of use_sharedlib as true since there maybe future cases where we may need to run tests with it as a shared lib (instead of assuming shared lib builds are always production builds). 

Let me know if that's the case.