### PR TITLE
Prepend brushlib directory rather than appending

### DIFF
--- a/lib/SConscript
+++ b/lib/SConscript
@@ -21,8 +21,8 @@ def build_py_module(env, *args, **kwargs):
 
 # Build against brushlib
 env.Prepend(LIBS=['mypaint-tests', "mypaint"])
-env.Append(LIBPATH="../brushlib")
-env.Append(CPPPATH=['../brushlib', '../brushlib/tests'])
+env.Prepend(LIBPATH="../brushlib")
+env.Prepend(CPPPATH=['../brushlib', '../brushlib/tests'])
 
 
 def parse_pkg_config(env, libname):


### PR DESCRIPTION
This ensures we get brushlib from the source directory, not a different one that might already be installed.

Before this change, MyPaint 1.2.0 builds like this:

    /usr/bin/clang++ -arch x86_64 -arch i386 -o _mypaintlib.so -O3 -dynamiclib lib/mypaintlib_wrap.os lib/fill.os lib/eventhack.os lib/gdkpixbuf2numpy.os lib/pixops.os lib/fastpng.os -L/opt/local/lib -Lbrushlib -L/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib -lmypaint-tests -lmypaint -lm -ljson-c -lpng16 -llcms2 -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0 -lintl -lpython2.7

`-L/opt/local/lib -Lbrushlib` means it will check for libmypaint-tests.a and libmypaint.a in /opt/local/lib first, and only if not found there will it look for them in brushlib. This can cause the build to fail if /opt/local/lib/libmypaint.a already exists, for example from another MyPaint installation. In my case, my already-installed MyPaint was built for x86_64 only, and I was now trying to build MyPaint universal (for x86_64 and i386); the build failed because i386 symbols were not found in the already-installed x86_64 version of the library. But it could fail for other reasons as well.