### PR TITLE
Edit menu: remove unnecessary Current Tool entries

### DIFF
--- a/gui/menu.xml
+++ b/gui/menu.xml
@@ -36,25 +36,6 @@
       <menuitem action='FlipSymmetryEditMode'/>
       <!-- All radio modes, in case somebody wants to bind those -->
       <separator/>
-      <menu action="CurrentModeMenu">
-        <menuitem action='FreehandMode'/>
-        <menuitem action='InkingMode'/>
-        <menuitem action='StraightMode'/>
-        <menuitem action='SequenceMode'/>
-        <menuitem action='EllipseMode'/>
-        <menuitem action='FloodFillMode'/>
-        <separator/>
-        <menuitem action='ColorPickMode'/>
-        <menuitem action='LayerMoveMode'/>
-        <separator/>
-        <menuitem action='FrameEditMode'/>
-        <menuitem action='SymmetryEditMode'/>
-        <separator/>
-        <menuitem action='PanViewMode'/>
-        <menuitem action='ZoomViewMode'/>
-        <menuitem action='RotateViewMode'/>
-      </menu>
-      <separator/>
       <menuitem action='RevealModeOptionsTool'/>
       <menuitem action='RevealHistoryPanel'/>
       <separator/>

--- a/gui/resources.xml
+++ b/gui/resources.xml
@@ -834,12 +834,6 @@ Vocabulary
           <!-- NO TOOLTIP: this is a menu -->
         </object>
       </child>
-      <child>
-        <object class="GtkAction" id="CurrentModeMenu">
-          <property name="label" translatable="yes" context="Menu→Edit (labels)">Current Tool</property>
-          <!-- NO TOOLTIP: this is a menu -->
-        </object>
-      </child>
       <!-- }}} -->
       <!-- {{{ Color menu structure & actions -->
       <child>


### PR DESCRIPTION
Changing accelerator keys under GTK no longer requires individual menu
entries for each option, so the Current Tool submenu is unnecessary.

Closes mypaint/mypaint#613