### PR TITLE
Scratchpad: Don't scroll on "size-allocate".

### DIFF
--- a/gui/application.py
+++ b/gui/application.py
@@ -303,6 +303,7 @@ class Application (object):
         self.scratchpad_filename = ""
         scratchpad_model = lib.document.Document(self.brush, painting_only=True)
         scratchpad_tdw = tileddrawwidget.TiledDrawWidget()
+        scratchpad_tdw.scroll_on_allocate = False
         scratchpad_tdw.set_model(scratchpad_model)
         self.scratchpad_doc = document.Document(self, scratchpad_tdw,
                                                 scratchpad_model)


### PR DESCRIPTION
Since TiledDrawWidget._size_allocate_cb() calculates offsets relative to the coordinates of the main window, it can be used only with the main viewport. 

Fixes mypaint/mypaint#597. You can easily reveal the problem by drawing something in the scratchpad and then resizing the main window.