### PR TITLE
Fix PyGTK-style Gdk.Window.get_origin().

### DIFF
--- a/gui/topbar.py
+++ b/gui/topbar.py
@@ -272,8 +272,7 @@ class FakeMenuButton (Gtk.EventBox):
         This places the menu underneath the button, at the same x position.
         """
         win = self.get_window()
-        origin = win.get_origin()
-        x, y = origin[-2:]   # early GTK3 returns 3-tuples
+        x, y = win.get_origin()[1:]
         y += self.get_allocated_height()
         return x, y, True
 

--- a/gui/windowing.py
+++ b/gui/windowing.py
@@ -347,7 +347,7 @@ class ChooserPopup (Gtk.Window):
             self.set_gravity(Gdk.Gravity.NORTH_WEST)
         else:
             win = widget.get_window()
-            x, y = win.get_origin()
+            x, y = win.get_origin()[1:]
             alloc = widget.get_allocation()
             #x += alloc.x
             #y += alloc.y


### PR DESCRIPTION
PyGI in addition returns a useless integer (the result of
gdk_window_get_origin()).

See:
  https://developer.gnome.org/gdk3/stable/gdk3-Windows.html
  pygtkcompat/pygtkcompat.py