### PR TITLE
Replace Gtk.Widget.drag_source_set_icon_pixbuf() with Gtk.drag_set_icon_pixbuf()

### DIFF
--- a/gui/brushselectionwindow.py
+++ b/gui/brushselectionwindow.py
@@ -125,7 +125,7 @@ class BrushList (pixbuflist.PixbufList):
         preview = preview.scale_simple(
             preview.get_width()//2, preview.get_height()//2,
             GdkPixbuf.InterpType.BILINEAR)
-        self.drag_source_set_icon_pixbuf(preview)
+        Gtk.drag_set_icon_pixbuf(context, preview, 0, 0)
         super(BrushList, self).drag_begin_cb(widget, context)
 
     def on_drag_data(self, copy, source_widget, brush_dragid, target_idx):

--- a/gui/colors/adjbases.py
+++ b/gui/colors/adjbases.py
@@ -569,7 +569,7 @@ class ColorAdjusterWidget (CachedBgDrawingArea, ColorAdjuster):
             GdkPixbuf.Colorspace.RGB, False, 8, 32, 32)
         pixel = color.to_fill_pixel()
         preview.fill(pixel)
-        self.drag_source_set_icon_pixbuf(preview)
+        Gtk.drag_set_icon_pixbuf(context, preview, 0, 0)
 
     def drag_end_cb(self, widget, context):
         pass


### PR DESCRIPTION
Gtk.drag_set_icon_pixbuf() is the right way to set the D&D icon
dynamically from the "drag-begin" event. drag_source_set_icon_pixbuf()
should be used to set a "static" icon.

In theory, they should work equally, but I noticed that icon set via
drag_source_set_icon_pixbuf() is not visible if its size is greater
than 55px (as in the brush list). Maybe it's a bug in GTK+ or
something desktop-specific (XFCE), but anyway it's better to use
the "right" way.

Examples from the GTK+ sources:
[gtk_drag_set_icon_pixbuf](https://github.com/GNOME/gtk/search?utf8=%E2%9C%93&q=gtk_drag_set_icon_pixbuf&type=Code)
[gtk_drag_source_set_icon_pixbuf](https://github.com/GNOME/gtk/search?utf8=%E2%9C%93&q=gtk_drag_source_set_icon_pixbuf&type=Code)