### PR TITLE
Standardize NumPy imports

### DIFF
--- a/gui/colors/hcywheel.py
+++ b/gui/colors/hcywheel.py
@@ -688,9 +688,9 @@ class HCYMaskEditorWheel (HCYHueChromaWheel):
         for hull in self.get_mask_voids():
             # cx, cy = geom.poly_centroid(hull)
             for p1, p2 in geom.pairwise(hull):
-                np = geom.nearest_point_in_segment(p1, p2, (x, y))
-                if np is not None:
-                    nx, ny = np
+                nearest_point = geom.nearest_point_in_segment(p1, p2, (x, y))
+                if nearest_point is not None:
+                    nx, ny = nearest_point
                     d = math.sqrt((x-nx)**2 + (y-ny)**2)
                     dists.append(d)
             # Segment end too

--- a/gui/displayfilter.py
+++ b/gui/displayfilter.py
@@ -13,7 +13,7 @@
 ## Imports
 
 
-import numpy
+import numpy as np
 
 
 ## Constants
@@ -48,7 +48,7 @@ _SIM_TRITANOPIA_B_COEFFS = (-0.063, 0.881, 0.182)
 def luma_only(dst):
     """Convert an NxNx3 array to show only luma (brightness)"""
     luma = (dst[...,0:3] * _LUMA_COEFFS).sum(axis=2)
-    dst[...,0:3] = luma[...,numpy.newaxis]
+    dst[..., 0:3] = luma[..., np.newaxis]
 
 
 def invert_colors(dst):
@@ -61,9 +61,9 @@ def sim_deuteranopia(dst):
     r = (dst[...,0:3] * _SIM_DEUTERANOPIA_R_COEFFS).sum(axis=2)
     g = (dst[...,0:3] * _SIM_DEUTERANOPIA_G_COEFFS).sum(axis=2)
     b = (dst[...,0:3] * _SIM_DEUTERANOPIA_B_COEFFS).sum(axis=2)
-    numpy.clip(r, 0, 255, dst[...,0])
-    numpy.clip(g, 0, 255, dst[...,1])
-    numpy.clip(b, 0, 255, dst[...,2])
+    np.clip(r, 0, 255, dst[..., 0])
+    np.clip(g, 0, 255, dst[..., 1])
+    np.clip(b, 0, 255, dst[..., 2])
 
 
 def sim_protanopia(dst):
@@ -71,9 +71,9 @@ def sim_protanopia(dst):
     r = (dst[...,0:3] * _SIM_PROTANOPIA_R_COEFFS).sum(axis=2)
     g = (dst[...,0:3] * _SIM_PROTANOPIA_G_COEFFS).sum(axis=2)
     b = (dst[...,0:3] * _SIM_PROTANOPIA_B_COEFFS).sum(axis=2)
-    numpy.clip(r, 0, 255, dst[...,0])
-    numpy.clip(g, 0, 255, dst[...,1])
-    numpy.clip(b, 0, 255, dst[...,2])
+    np.clip(r, 0, 255, dst[..., 0])
+    np.clip(g, 0, 255, dst[..., 1])
+    np.clip(b, 0, 255, dst[..., 2])
 
 
 def sim_tritanopia(dst):
@@ -81,6 +81,6 @@ def sim_tritanopia(dst):
     r = (dst[...,0:3] * _SIM_TRITANOPIA_R_COEFFS).sum(axis=2)
     g = (dst[...,0:3] * _SIM_TRITANOPIA_G_COEFFS).sum(axis=2)
     b = (dst[...,0:3] * _SIM_TRITANOPIA_B_COEFFS).sum(axis=2)
-    numpy.clip(r, 0, 255, dst[...,0])
-    numpy.clip(g, 0, 255, dst[...,1])
-    numpy.clip(b, 0, 255, dst[...,2])
+    np.clip(r, 0, 255, dst[..., 0])
+    np.clip(g, 0, 255, dst[..., 1])
+    np.clip(b, 0, 255, dst[..., 2])

--- a/gui/drawutils.py
+++ b/gui/drawutils.py
@@ -18,7 +18,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 import math
-from numpy import array
+
+import numpy as np
 import cairo
 
 from lib.helpers import clamp
@@ -97,15 +98,15 @@ def spline_iter(tuples, double_first=True, double_last=True):
     cint = [None, None, None, None]
     if double_first:
         cint[0:3] = cint[1:4]
-        cint[3] = array(tuples[0])
+        cint[3] = np.array(tuples[0])
     for ctrlpt in tuples:
         cint[0:3] = cint[1:4]
-        cint[3] = array(ctrlpt)
+        cint[3] = np.array(ctrlpt)
         if not any((a is None) for a in cint):
             yield cint
     if double_last:
         cint[0:3] = cint[1:4]
-        cint[3] = array(tuples[-1])
+        cint[3] = np.array(tuples[-1])
         yield cint
 
 

--- a/gui/freehand.py
+++ b/gui/freehand.py
@@ -11,8 +11,6 @@
 ## Imports
 
 import math
-from numpy import array
-from numpy import isfinite
 from lib.helpers import clamp
 import logging
 from collections import deque
@@ -23,6 +21,8 @@ from gettext import gettext as _
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GLib
+
+import numpy as np
 
 from lib import brushsettings
 
@@ -490,13 +490,13 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
         if drawstate.button_down is not None:
             if pressure == 0.0:
                 pressure = drawstate.last_good_raw_pressure
-            elif pressure is not None and isfinite(pressure):
+            elif pressure is not None and np.isfinite(pressure):
                 drawstate.last_good_raw_pressure = pressure
 
         # Ensure each non-evhack event has a defined pressure
         if pressure is not None:
             # Using the reported pressure. Apply some sanity checks
-            if not isfinite(pressure):
+            if not np.isfinite(pressure):
                 # infinity/nan: use button state (instead of clamping in
                 # brush.hpp) https://gna.org/bugs/?14709
                 pressure = None
@@ -516,7 +516,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
         # Check whether tilt is present.  For some tablets without
         # tilt support GTK reports a tilt axis with value nan, instead
         # of None.  https://gna.org/bugs/?17084
-        if xtilt is None or ytilt is None or not isfinite(xtilt+ytilt):
+        if xtilt is None or ytilt is None or not np.isfinite(xtilt + ytilt):
             xtilt = 0.0
             ytilt = 0.0
 
@@ -831,12 +831,12 @@ class PressureAndTiltInterpolator (object):
             dt = t1 - t0
             can_interp = dt > 0
         if can_interp:
-            for np in self._np:
-                t, x, y = np[0:3]
+            for event in self._np:
+                t, x, y = event[0:3]
                 p, xt, yt = spline_4p(
                     float(t - t0) / dt,
-                    array(pt0p[3:]), array(pt0[3:]),
-                    array(pt1[3:]), array(pt1n[3:])
+                    np.array(pt0p[3:]), np.array(pt0[3:]),
+                    np.array(pt1[3:]), np.array(pt1n[3:])
                 )
                 yield (t, x, y, p, xt, yt)
         if pt1 is not None:

--- a/gui/inktool.py
+++ b/gui/inktool.py
@@ -10,7 +10,6 @@
 ## Imports
 
 import math
-from numpy import isfinite
 import collections
 import weakref
 import os.path
@@ -22,6 +21,7 @@ import gi
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GLib
+import numpy as np
 
 import gui.mode
 import gui.overlays
@@ -627,7 +627,7 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         # FIXME: CODE DUPLICATION: copied from freehand.py
         pressure = event.get_axis(Gdk.AxisUse.PRESSURE)
         if pressure is not None:
-            if not isfinite(pressure):
+            if not np.isfinite(pressure):
                 pressure = None
             else:
                 pressure = lib.helpers.clamp(pressure, 0.0, 1.0)
@@ -646,7 +646,7 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         if self._button_down is not None:
             if pressure == 0.0:
                 pressure = self._last_good_raw_pressure
-            elif pressure is not None and isfinite(pressure):
+            elif pressure is not None and np.isfinite(pressure):
                 self._last_good_raw_pressure = pressure
         return pressure
 
@@ -654,7 +654,7 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         # FIXME: CODE DUPLICATION: copied from freehand.py
         xtilt = event.get_axis(Gdk.AxisUse.XTILT)
         ytilt = event.get_axis(Gdk.AxisUse.YTILT)
-        if xtilt is None or ytilt is None or not isfinite(xtilt+ytilt):
+        if xtilt is None or ytilt is None or not np.isfinite(xtilt + ytilt):
             return (0.0, 0.0)
 
         # Switching from a non-tilt device to a device which reports

--- a/gui/tileddrawwidget.py
+++ b/gui/tileddrawwidget.py
@@ -14,8 +14,6 @@ import os
 import random
 from math import floor, ceil, log, exp
 import math
-from numpy import isfinite
-from numpy import empty
 from warnings import warn
 import weakref
 import contextlib
@@ -26,6 +24,7 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GLib
 import cairo
+import numpy as np
 
 from lib import helpers, tiledsurface, pixbufsurface
 from lib.observable import event
@@ -752,7 +751,7 @@ class CanvasRenderer (Gtk.DrawingArea, DrawCursorMixin):
         pattern.set_extend(cairo.EXTEND_REPEAT)
         self._real_alpha_check_pattern = pattern
         # Fake: faster rendering, but ugly
-        tile = empty((N, N, 4), dtype='uint16')
+        tile = np.empty((N, N, 4), dtype='uint16')
         f = 1 << 15
         col1 = [int(f * c) for c in gui.style.ALPHA_CHECK_COLOR_1] + [f]
         col2 = [int(f * c) for c in gui.style.ALPHA_CHECK_COLOR_2] + [f]

--- a/lib/SConscript
+++ b/lib/SConscript
@@ -109,7 +109,7 @@ if env.get("numpy_include"):
 # syntax too much, causing os.path.join() to fail.
 
 if not numpy_path:
-    numpy_cfg_py = "import numpy; print numpy.get_include()"
+    numpy_cfg_py = "import numpy as np; print np.get_include()"
     try:
         numpy_path = subprocess.check_output([
             env["python_binary"],
@@ -128,8 +128,8 @@ if not numpy_path:
 
 if not numpy_path:
     try:
-        import numpy
-        numpy_path = numpy.get_include()
+        import numpy as np
+        numpy_path = np.get_include()
     except:
         numpy_path = None
 

--- a/lib/color.py
+++ b/lib/color.py
@@ -173,8 +173,8 @@ class UIColor (object):
             return False
         return rgb1 == rgb2
         # colorhistory.py uses
-        #a_ = numpy.array(helpers.hsv_to_rgb(*a))
-        #b_ = numpy.array(helpers.hsv_to_rgb(*b))
+        #a_ = np.array(helpers.hsv_to_rgb(*a))
+        #b_ = np.array(helpers.hsv_to_rgb(*b))
         #return ((a_ - b_)**2).sum() < (3*1.0/256)**2
 
     def __copy__(self):

--- a/lib/document.py
+++ b/lib/document.py
@@ -32,7 +32,7 @@ from gi.repository import GdkPixbuf
 from gi.repository import GObject
 from gi.repository import GLib
 
-import numpy
+import numpy as np
 
 import lib.helpers as helpers
 import lib.fileutils as fileutils
@@ -296,7 +296,7 @@ class Document (object):
         self._yres = None
 
         # Backgrounds for rendering
-        blank_arr = numpy.zeros((N, N, 4), dtype='uint16')
+        blank_arr = np.zeros((N, N, 4), dtype='uint16')
         self._blank_bg_surface = tiledsurface.Background(blank_arr)
 
         # And begin in a known state

--- a/lib/fileutils.py
+++ b/lib/fileutils.py
@@ -23,7 +23,6 @@ import colorsys
 import urllib
 import gc
 import functools
-import numpy
 import logging
 logger = logging.getLogger(__name__)
 import shutil

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -214,7 +214,7 @@ def gdkpixbuf2numpy(pixbuf):
     # assert pixbuf.get_bits_per_sample() == 8
     # assert pixbuf.get_has_alpha()
     # assert pixbuf.get_n_channels() == 4
-    # arr = numpy.frombuffer(pixbuf.get_pixels(), dtype=numpy.uint8)
+    # arr = np.frombuffer(pixbuf.get_pixels(), dtype=np.uint8)
     # arr = arr.reshape(h, w, 4)
     # return arr
 

--- a/lib/layer/group.py
+++ b/lib/layer/group.py
@@ -12,9 +12,10 @@
 
 ## Imports
 
-import numpy
 import logging
 logger = logging.getLogger(__name__)
+
+import numpy as np
 
 from lib.gettext import C_
 import lib.mypaintlib
@@ -70,7 +71,7 @@ class LayerStack (core.LayerBase, lib.autosave.Autosaveable):
         super(LayerStack, self).__init__(**kwargs)
         # Blank background, for use in rendering
         N = tiledsurface.N
-        blank_arr = numpy.zeros((N, N, 4), dtype='uint16')
+        blank_arr = np.zeros((N, N, 4), dtype='uint16')
         self._blank_bg_surface = tiledsurface.Background(blank_arr)
 
     def load_from_openraster(self, orazip, elem, cache_dir, feedback_cb,
@@ -369,7 +370,7 @@ class LayerStack (core.LayerBase, lib.autosave.Autosaveable):
                        **kwargs):
         """Unconditionally copy one tile's data into an array"""
         N = tiledsurface.N
-        tmp = numpy.zeros((N, N, 4), dtype='uint16')
+        tmp = np.zeros((N, N, 4), dtype='uint16')
         for layer in reversed(self._layers):
             layer.composite_tile(tmp, True, tx, ty, mipmap_level,
                                  layers=None, **kwargs)
@@ -408,7 +409,7 @@ class LayerStack (core.LayerBase, lib.autosave.Autosaveable):
             isolate = False
         if isolate:
             N = tiledsurface.N
-            tmp = numpy.zeros((N, N, 4), dtype='uint16')
+            tmp = np.zeros((N, N, 4), dtype='uint16')
             for layer in reversed(self._layers):
                 p = (self is previewing) and layer or previewing
                 s = (self is solo) and layer or solo

--- a/lib/layer/tree.py
+++ b/lib/layer/tree.py
@@ -15,12 +15,13 @@
 from gi.repository import GdkPixbuf
 
 import re
-import numpy
 import logging
 logger = logging.getLogger(__name__)
 from warnings import warn
 from copy import deepcopy
 import os.path
+
+import numpy as np
 
 from lib.gettext import C_
 import lib.mypaintlib
@@ -390,7 +391,7 @@ class RootLayerStack (group.LayerStack):
                              render_background, id(opaque_base_tile))
                 dst = self._render_cache.get(cache_key)
             if dst is None:
-                dst = numpy.empty((N, N, 4), dtype='uint16')
+                dst = np.empty((N, N, 4), dtype='uint16')
             else:
                 cache_hit = True
         else:
@@ -404,7 +405,7 @@ class RootLayerStack (group.LayerStack):
                     opaque_base_tile,
                     dst_over_opaque_base,
                 )
-                dst = numpy.empty((N, N, 4), dtype='uint16')
+                dst = np.empty((N, N, 4), dtype='uint16')
 
             background_surface.blit_tile_into(dst, dst_has_alpha, tx, ty,
                                               mipmap_level)
@@ -1586,7 +1587,7 @@ class RootLayerStack (group.LayerStack):
         dstsurf = dstlayer._surface
         N = tiledsurface.N
         for tx, ty in tiles:
-            bd = numpy.zeros((N, N, 4), dtype='uint16')
+            bd = np.zeros((N, N, 4), dtype='uint16')
             for layer in backdrop_layers:
                 if layer is self._background_layer:
                     surf = self._background_layer._surface

--- a/lib/pixbufsurface.py
+++ b/lib/pixbufsurface.py
@@ -10,7 +10,6 @@
 
 import sys
 import contextlib
-import numpy
 from logging import getLogger
 logger = getLogger(__name__)
 

--- a/lib/stroke.py
+++ b/lib/stroke.py
@@ -6,8 +6,9 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import numpy as np
+
 import brush
-import numpy
 
 
 class Stroke (object):
@@ -56,7 +57,7 @@ class Stroke (object):
         # OPTIMIZE
         # - for space: just gzip? use integer datatypes?
         # - for time: maybe already use array storage while recording?
-        data = numpy.array(self.tmp_event_list, dtype='float64')
+        data = np.array(self.tmp_event_list, dtype='float64')
         data = data.tostring()
         version = '2'
         self.stroke_data = version + data
@@ -79,7 +80,7 @@ class Stroke (object):
         # OPTIMIZE: check if parsing of settings is a performance bottleneck
         b = brush.Brush(brush.BrushInfo(self.brush_settings))
 
-        states = numpy.fromstring(self.brush_state, dtype='float32')
+        states = np.fromstring(self.brush_state, dtype='float32')
         b.set_states_from_array(states)
 
         #b.set_print_inputs(1)
@@ -87,7 +88,7 @@ class Stroke (object):
 
         version, data = self.stroke_data[0], self.stroke_data[1:]
         assert version == '2'
-        data = numpy.fromstring(data, dtype='float64')
+        data = np.fromstring(data, dtype='float64')
         data.shape = (len(data)/6, 6)
 
         surface.begin_atomic()

--- a/lib/strokemap.py
+++ b/lib/strokemap.py
@@ -12,10 +12,11 @@
 import time
 import struct
 import zlib
-import numpy
 import math
 from logging import getLogger
 logger = getLogger(__name__)
+
+import numpy as np
 
 import mypaintlib
 
@@ -329,7 +330,7 @@ class _TileTranslateTask:
                 else:
                     targ = self._targ.get((targ_tx, targ_ty), None)
                     if targ is None:
-                        targ = numpy.zeros((N, N), 'uint8')
+                        targ = np.zeros((N, N), 'uint8')
                         self._targ[targ_tx, targ_ty] = targ
                     targ[targ_y0:targ_y1, targ_x0:targ_x1] \
                         = src[src_y0:src_y1, src_x0:src_x1]
@@ -390,7 +391,7 @@ class _Tile:
 
     """
 
-    _ZDATA_ONES = zlib.compress(numpy.ones((N, N), 'uint8').tostring())
+    _ZDATA_ONES = zlib.compress(np.ones((N, N), 'uint8').tostring())
 
     def __init__(self):
         """Initialize, as a tile filled with all ones."""
@@ -400,7 +401,7 @@ class _Tile:
     @classmethod
     def new_from_diff(cls, before, after):
         """Initialize from a diff or two RGBA arrays."""
-        differences = numpy.empty((N, N), 'uint8')
+        differences = np.empty((N, N), 'uint8')
         mypaintlib.tile_perceptual_change_strokemap(
             before,
             after,
@@ -436,9 +437,9 @@ class _Tile:
     def to_array(self):
         """Convert to an uncompressed array of ones and zeros."""
         if self._all:
-            array = numpy.ones((N, N), 'uint8')
+            array = np.ones((N, N), 'uint8')
         else:
-            array = numpy.fromstring(
+            array = np.fromstring(
                 zlib.decompress(self._zdata),
                 dtype='uint8',
             )

--- a/lib/surface.py
+++ b/lib/surface.py
@@ -13,11 +13,12 @@
 
 import abc
 import contextlib
-import numpy
 import sys
 import os
 import logging
 logger = logging.getLogger(__name__)
+
+import numpy as np
 
 import mypaintlib
 import lib.helpers
@@ -155,7 +156,7 @@ class TileRequestWrapper (TileAccessible):
             raise ValueError("Only readonly tile requests are supported")
         tile = self._cache.get((tx, ty), None)
         if tile is None:
-            tile = numpy.zeros((N, N, 4), 'uint16')
+            tile = np.zeros((N, N, 4), 'uint16')
             self._cache[(tx, ty)] = tile
             self._obj.composite_tile(tile, True, tx, ty, **self._opts)
         yield tile
@@ -209,7 +210,7 @@ def scanline_strips_iter(surface, rect, alpha=False,
     render_th = (y+h-1)/N - render_ty + 1
 
     # buffer for rendering one tile row at a time
-    arr = numpy.empty((1*N, render_tw*N, 4), 'uint8')  # rgba or rgbu
+    arr = np.empty((N, render_tw * N, 4), 'uint8')  # rgba or rgbu
     # view into arr without the horizontal padding
     arr_xcrop = arr[:, x-render_tx*N:x-render_tx*N+w, :]
 

--- a/lib/tiledsurface.py
+++ b/lib/tiledsurface.py
@@ -10,7 +10,6 @@
 
 ## Imports
 
-import numpy
 import time
 import sys
 import os
@@ -19,6 +18,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from gettext import gettext as _
+import numpy as np
 
 import mypaintlib
 import helpers
@@ -52,7 +52,7 @@ class _Tile (object):
     def __init__(self, copy_from=None):
         super(_Tile, self).__init__()
         if copy_from is None:
-            self.rgba = numpy.zeros((N, N, 4), 'uint16')
+            self.rgba = np.zeros((N, N, 4), 'uint16')
         else:
             self.rgba = copy_from.rgba.copy()
         self.readonly = False
@@ -504,7 +504,7 @@ class MyPaintSurface (TileAccessible, TileBlittable, TileCompositable):
             if state['buf'] is not None:
                 consume_buf()
             else:
-                state['buf'] = numpy.empty((buf_h, buf_w, 4), 'uint8')
+                state['buf'] = np.empty((buf_h, buf_w, 4), 'uint8')
 
             png_x0 = x
             png_x1 = x+png_w
@@ -936,9 +936,9 @@ class Background (Surface):
         :param mipmap_level: mipmap level, used internally. Root is zero.
         """
 
-        if not isinstance(obj, numpy.ndarray):
+        if not isinstance(obj, np.ndarray):
             r, g, b = obj
-            obj = numpy.zeros((N, N, 3), dtype='uint8')
+            obj = np.zeros((N, N, 3), dtype='uint8')
             obj[:, :, :] = r, g, b
 
         height, width = obj.shape[0:2]
@@ -951,7 +951,7 @@ class Background (Surface):
 
         # Generate mipmap
         if mipmap_level <= MAX_MIPMAP_LEVEL:
-            mipmap_obj = numpy.zeros((height, width, 4), dtype='uint16')
+            mipmap_obj = np.zeros((height, width, 4), dtype='uint16')
             for ty in range(height/N*2):
                 for tx in range(width/N*2):
                     with self.tile_request(tx, ty, readonly=True) as src:
@@ -1070,7 +1070,7 @@ def flood_fill(src, x, y, color, bbox, tolerance, dst):
         with src.tile_request(tx, ty, readonly=True) as src_tile:
             dst_tile = filled.get((tx, ty), None)
             if dst_tile is None:
-                dst_tile = numpy.zeros((N, N, 4), 'uint16')
+                dst_tile = np.zeros((N, N, 4), 'uint16')
                 filled[(tx, ty)] = dst_tile
             overflows = mypaintlib.tile_flood_fill(
                 src_tile, dst_tile, seeds,

--- a/tests/guicontrol.py
+++ b/tests/guicontrol.py
@@ -4,7 +4,8 @@ import traceback
 import tempfile
 import os
 import sys
-import numpy
+
+import numpy as np
 
 
 class GUI:
@@ -82,8 +83,8 @@ class GUI:
 
     def scroll(self, N=20):
         tdw = self.app.doc.tdw
-        dx = numpy.linspace(-30, 30, N)
-        dy = numpy.linspace(-10, 60, N)
+        dx = np.linspace(-30, 30, N)
+        dy = np.linspace(-10, 60, N)
         for i in xrange(N):
             tdw.scroll(int(dx[i]), int(dy[i]))
             self.wait_for_idle()

--- a/tests/test_compositeops.py
+++ b/tests/test_compositeops.py
@@ -2,10 +2,11 @@
 # Tests the layer compositing/blending code for correctness of its
 # advertized optimization flags.
 
-import numpy
 import os
 import sys
 from random import random
+
+import numpy as np
 
 os.chdir(os.path.dirname(sys.argv[0]))
 sys.path.insert(0, '..')
@@ -43,8 +44,8 @@ assert mypaintlib.heavy_debug, \
 
 # Prepare striped test data in a tile array
 FIX15_ONE = 1 << 15
-src = numpy.empty((N, N, 4), dtype='uint16')
-dst_orig = numpy.empty((N, N, 4), dtype='uint16')
+src = np.empty((N, N, 4), dtype='uint16')
+dst_orig = np.empty((N, N, 4), dtype='uint16')
 for i, rgba1 in enumerate(SAMPLE_DATA):
     r1 = int(FIX15_ONE * rgba1[0] * rgba1[3])
     g1 = int(FIX15_ONE * rgba1[1] * rgba1[3])
@@ -73,7 +74,7 @@ for mode in xrange(mypaintlib.NumCombineModes):
     mode_name = mode_info["name"]
     print mode_name,
 
-    dst = numpy.empty((N, N, 4), dtype='uint16')
+    dst = np.empty((N, N, 4), dtype='uint16')
     dst[...] = dst_orig[...]
 
     # Combine using the current mode

--- a/tests/test_memory_leak.py
+++ b/tests/test_memory_leak.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-import numpy
 from time import time
 import sys
 import os
 import gc
+
+import numpy as np
 
 os.chdir(os.path.dirname(sys.argv[0]))
 sys.path.insert(0, '..')
@@ -13,7 +14,7 @@ import guicontrol
 
 # loadtxt is known to leak memory, thus we run it only once
 # http://projects.scipy.org/numpy/ticket/1356
-painting30sec_events = numpy.loadtxt('painting30sec.dat')
+painting30sec_events = np.loadtxt('painting30sec.dat')
 
 LEAK_EXIT_CODE = 33
 
@@ -90,13 +91,13 @@ def provoke_leak():
     for i in iterations():
         # note: interestingly this leaky only shows in the later iterations
         #       (and very small leaks might not be detected)
-        setattr(gc, 'my_test_leak_%d' % i, numpy.zeros(50000))
+        setattr(gc, 'my_test_leak_%d' % i, np.zeros(50000))
 
 
 @leaktest
 def noleak():
     for i in iterations():
-        setattr(gc, 'my_test_leak', numpy.zeros(50000))
+        setattr(gc, 'my_test_leak', np.zeros(50000))
 
 
 @leaktest

--- a/tests/test_mypaintlib.py
+++ b/tests/test_mypaintlib.py
@@ -131,11 +131,13 @@ def files_equal(a, b):
 
 
 def pngs_equal(a, b):
+    import matplotlib.pyplot as plt
+
     if files_equal(a, b):
         print a, 'and', b, 'are perfectly equal'
         return True
-    im_a = numpy.imread(a)*255.0
-    im_b = numpy.imread(b)*255.0
+    im_a = plt.imread(a) * 255.0
+    im_b = plt.imread(b) * 255.0
     if im_a.shape != im_b.shape:
         print a, 'and', b, 'have different size:', im_a.shape, im_b.shape
         return False
@@ -151,7 +153,7 @@ def pngs_equal(a, b):
     print 'Average difference with premultiplied alpha (255=white): (R, G, B, A)'
     diff = diff[:, :, 0:3]
     if alpha:
-        diff *= numpy.imread(a)[:, :, 3:4]
+        diff *= plt.imread(a)[:, :, 3:4]
     res = numpy.mean(numpy.mean(diff, 0), 0)
     print res
     if numpy.mean(res) > 0.01:
@@ -169,20 +171,20 @@ def pngs_equal(a, b):
     if not equal:
         print 'Not equal enough!'
         if alpha:
-            numpy.figure(1)
-            numpy.title('Alpha')
-            numpy.imshow(im_b[:, :, 3], interpolation='nearest')
-            numpy.colorbar()
-        numpy.figure(2)
-        numpy.title('Green Error (multiplied with alpha)')
-        numpy.imshow(diff[:, :, 1], interpolation='nearest')
-        numpy.colorbar()
+            plt.figure(1)
+            plt.title('Alpha')
+            plt.imshow(im_b[:, :, 3], interpolation='nearest')
+            plt.colorbar()
+        plt.figure(2)
+        plt.title('Green Error (multiplied with alpha)')
+        plt.imshow(diff[:, :, 1], interpolation='nearest')
+        plt.colorbar()
         if alpha:
-            numpy.figure(3)
-            numpy.title('Alpha Error')
-            numpy.imshow(diff_alpha, interpolation='nearest')
-            numpy.colorbar()
-        numpy.show()
+            plt.figure(3)
+            plt.title('Alpha Error')
+            plt.imshow(diff_alpha, interpolation='nearest')
+            plt.colorbar()
+        plt.show()
 
     return equal
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -9,7 +9,7 @@ from time import time, sleep
 import distutils.spawn
 
 from gi.repository import Gtk, Gdk
-from numpy import math, linspace, loadtxt
+import numpy as np
 
 os.chdir(os.path.dirname(sys.argv[0]))
 sys.path.insert(0, '..')
@@ -93,8 +93,7 @@ def paint(gui):
     gui.wait_for_duration(1.5)  # fullscreen seems to take some time to get through...
     gui.wait_for_idle()
 
-    events = loadtxt('painting30sec.dat')
-    events = list(events)
+    events = np.loadtxt('painting30sec.dat')
     yield start_measurement
     t_old = 0.0
     t_last_redraw = 0.0
@@ -145,7 +144,7 @@ def layerpaint_zoomed_out_5x(gui):
 @gui_test
 def paint_rotated(gui):
     gui.wait_for_idle()
-    gui.app.doc.tdw.rotate(46.0/360*2*math.pi)
+    gui.app.doc.tdw.rotate(46.0/360*2*np.pi)
     for res in paint(gui):
         yield res
 
@@ -207,7 +206,7 @@ def brushengine_paint_hires():
     bi = brush.BrushInfo(open('brushes/watercolor.myb').read())
     b = brush.Brush(bi)
 
-    events = loadtxt('painting30sec.dat')
+    events = np.loadtxt('painting30sec.dat')
     t_old = events[0][0]
     yield start_measurement
     s.begin_atomic()


### PR DESCRIPTION
The convention is `import numpy as np`, so use that instead of the various other forms.