### PR TITLE
py3k: Use new-style division

### DIFF
--- a/desktop/mypaint-ora-thumbnailer.py
+++ b/desktop/mypaint-ora-thumbnailer.py
@@ -46,7 +46,7 @@ def ora_thumbnail(infile, outfile, size):
     orig_w = pixbuf.get_width()
     orig_h = pixbuf.get_height()
     if orig_w > size or orig_h > size:
-        scale_factor = float(size) / max(orig_w, orig_h)
+        scale_factor = size / max(orig_w, orig_h)
         new_w = int(orig_w * scale_factor)
         new_h = int(orig_h * scale_factor)
         pixbuf = pixbuf.scale_simple(

--- a/desktop/mypaint-ora-thumbnailer.py
+++ b/desktop/mypaint-ora-thumbnailer.py
@@ -25,7 +25,7 @@
 # the shared-mime-info package, or see
 # http://standards.freedesktop.org/shared-mime-info-spec/
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import zipfile
 from gi.repository import GdkPixbuf

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,3 +1,3 @@
 
-from __future__ import print_function
+from __future__ import division, print_function
 

--- a/gui/accelmap.py
+++ b/gui/accelmap.py
@@ -10,7 +10,7 @@
 """Global AccelMap editor, for backwards compatibility"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 

--- a/gui/application.py
+++ b/gui/application.py
@@ -10,7 +10,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 # Know now that these are the rules of import.
 # That we live by, by which we abide.

--- a/gui/autorecover.py
+++ b/gui/autorecover.py
@@ -9,7 +9,7 @@
 
 """Autorecovery UI"""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import weakref
 import os.path

--- a/gui/backgroundwindow.py
+++ b/gui/backgroundwindow.py
@@ -9,7 +9,7 @@
 """Background tile chooser dialog"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import sys

--- a/gui/backgroundwindow.py
+++ b/gui/backgroundwindow.py
@@ -119,7 +119,7 @@ class BackgroundWindow (windowing.Dialog):
     def _get_selected_color_pixbuf(self):
         rgb = self.cs.get_current_color()
         rgb = (rgb.red, rgb.green, rgb.blue)
-        rgb = (float(c) / 0xffff for c in rgb)
+        rgb = (c / 0xffff for c in rgb)
         pixbuf = new_blank_pixbuf(rgb, N, N)
         return pixbuf
 
@@ -276,7 +276,7 @@ class BackgroundList (pixbuflist.PixbufList):
             return pixbuf
         assert w >= N
         assert h >= N
-        scale = max(0.25, float(N) / min(w, h))
+        scale = max(0.25, N / min(w, h))
         scaled = new_blank_pixbuf((0, 0, 0), N, N)
         pixbuf.composite(
             dest=scaled,

--- a/gui/brushcolor.py
+++ b/gui/brushcolor.py
@@ -10,7 +10,7 @@
 """Brush color changer.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gettext import gettext as _
 

--- a/gui/brusheditor.py
+++ b/gui/brusheditor.py
@@ -13,7 +13,7 @@
 
 # Imports:
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import logging

--- a/gui/brushiconeditor.py
+++ b/gui/brushiconeditor.py
@@ -8,7 +8,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 logger = logging.getLogger(__name__)

--- a/gui/brushmanager.py
+++ b/gui/brushmanager.py
@@ -11,7 +11,7 @@
 """File management for brushes and brush groups."""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import zipfile

--- a/gui/brushmodifier.py
+++ b/gui/brushmodifier.py
@@ -6,7 +6,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gettext import gettext as _
 from lib.helpers import rgb_to_hsv, hsv_to_rgb

--- a/gui/brushselectionwindow.py
+++ b/gui/brushselectionwindow.py
@@ -16,7 +16,7 @@ They are responsible for ordering, loading and saving brush lists.
 """
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 
@@ -109,9 +109,9 @@ class BrushList (pixbuflist.PixbufList):
                 self.NATURAL_WIDTH_NICONS * self.ICON_SIZE)
 
     def do_get_preferred_height_for_width(self, width):
-        icons_wide = max(1, int(width / self.ICON_SIZE))
+        icons_wide = max(1, int(width // self.ICON_SIZE))
         num_brushes = len(self.brushes)
-        icons_tall = max(int(num_brushes / icons_wide),
+        icons_tall = max(int(num_brushes // icons_wide),
                          max(self.MIN_HEIGHT_NICONS, 1))
         if icons_tall * icons_wide < num_brushes:
             icons_tall += 1

--- a/gui/builderhacks.py
+++ b/gui/builderhacks.py
@@ -11,7 +11,7 @@
 """Hacks for loading stuff from GtkBuilder files."""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import gi
 from gi.repository import Gtk

--- a/gui/buttonmap.py
+++ b/gui/buttonmap.py
@@ -9,7 +9,7 @@
 """Button press mapping.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gettext import gettext as _
 

--- a/gui/colorpicker.py
+++ b/gui/colorpicker.py
@@ -7,7 +7,7 @@
 # (at your option) any later version.
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import math
 

--- a/gui/colorpreview.py
+++ b/gui/colorpreview.py
@@ -12,7 +12,7 @@
 # TODO:   with a history row taking up the bottom. For now let's draw it at
 # TODO:   an aspect ratio of about 1:5 and see how users like it.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from colors import PreviousCurrentColorAdjuster
 
@@ -50,7 +50,7 @@ class BrushColorIndicator (PreviousCurrentColorAdjuster):
         if event.type != Gdk.EventType.BUTTON_PRESS:
             return False
         width = widget.get_allocated_width()
-        if event.x > width / 2:
+        if event.x > width // 2:
             return False
         self._button = event.button
         return True

--- a/gui/colors/__init__.py
+++ b/gui/colors/__init__.py
@@ -10,7 +10,7 @@
 """Color manipulation submodule.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from adjbases import ColorManager
 from adjbases import ColorAdjuster

--- a/gui/colors/adjbases.py
+++ b/gui/colors/adjbases.py
@@ -10,7 +10,7 @@
 """Manager+adjuster bases for tweaking a single color via many widgets.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import math
 from copy import deepcopy, copy
@@ -834,7 +834,7 @@ class IconRenderableColorAdjusterWidget (ColorAdjusterWidget, IconRenderable):
         suggested small outer border.
 
         """
-        b = max(2, int(size / 16))
+        b = max(2, int(size // 16))
         self.render_background_cb(cr, wd=size, ht=size, icon_border=b)
 
 
@@ -876,10 +876,10 @@ class PreviousCurrentColorAdjuster (ColorAdjusterWidget):
         cr.set_line_width(self.OUTLINE_WIDTH)
         cr.stroke()
 
-        cr.rectangle(b, b, int(eff_wd / 2), eff_ht)
+        cr.rectangle(b, b, int(eff_wd // 2), eff_ht)
         cr.set_source_rgb(*curr.get_rgb())
         cr.fill()
-        cr.rectangle(wd / 2, b, eff_wd - int(eff_wd / 2), eff_ht)
+        cr.rectangle(wd // 2, b, eff_wd - int(eff_wd // 2), eff_ht)
         cr.set_source_rgb(*prev.get_rgb())
         cr.fill()
 
@@ -905,7 +905,7 @@ class PreviousCurrentColorAdjuster (ColorAdjusterWidget):
     def get_color_at_position(self, x, y):
         alloc = self.get_allocation()
         mgr = self.get_color_manager()
-        if x < alloc.width / 2:
+        if x < alloc.width // 2:
             color = mgr.get_color()
         else:
             color = mgr.get_previous_color()
@@ -1122,8 +1122,8 @@ class HueSaturationWheelMixin(object):
                 alloc = self.get_allocation()
             wd = alloc.width
             ht = alloc.height
-        cx = int(wd / 2)
-        cy = int(ht / 2)
+        cx = int(wd // 2)
+        cy = int(ht // 2)
         return cx, cy
 
     def get_background_validity(self):
@@ -1306,8 +1306,8 @@ class HueSaturationWheelMixin(object):
         """
         col = self.get_managed_color()
         radius = self.get_radius(wd, ht, self.BORDER_WIDTH)
-        cx = int(wd / 2)
-        cy = int(ht / 2)
+        cx = int(wd // 2)
+        cy = int(ht // 2)
         cr.arc(cx, cy, radius + 0.5, 0, 2 * math.pi)
         cr.clip()
         x, y = self.get_pos_for_color(col)

--- a/gui/colors/adjbases.py
+++ b/gui/colors/adjbases.py
@@ -970,7 +970,7 @@ class SliderColorAdjuster (ColorAdjusterWidget):
             bar_gradient = cairo.LinearGradient(b, 0, b + bar_length, 0)
         samples = self.samples + 2
         for s in xrange(samples + 1):
-            p = float(s) / samples
+            p = s / samples
             col = self.get_color_for_bar_amount(p)
             r, g, b = col.get_rgb()
             if self.vertical:
@@ -1144,7 +1144,7 @@ class HueSaturationWheelMixin(object):
         cx, cy = self.get_center(alloc=alloc)
         # Normalized radius
         r = math.sqrt((x - cx) ** 2 + (y - cy) ** 2)
-        radius = float(self.get_radius(alloc=alloc))
+        radius = self.get_radius(alloc=alloc)
         if r > radius:
             r = radius
         r /= radius
@@ -1196,7 +1196,7 @@ class HueSaturationWheelMixin(object):
         step_angle = 2.0 * math.pi / steps
         mgr = self.get_color_manager()
         for ih in xrange(steps + 1):  # overshoot by 1, no solid bit for final
-            h = float(ih) / steps
+            h = ih / steps
             if mgr:
                 h = mgr.undistort_hue(h)
             edge_col = self.color_at_normalized_polar_pos(1.0, h)
@@ -1207,7 +1207,7 @@ class HueSaturationWheelMixin(object):
                 x, y = cr.get_current_point()
                 cr.line_to(0, 0)
                 cr.close_path()
-                lg = cairo.LinearGradient(radius, 0, float(x + radius) / 2, y)
+                lg = cairo.LinearGradient(radius, 0, (x + radius) / 2, y)
                 lg.add_color_stop_rgba(0, rgb[0], rgb[1], rgb[2], 1.0)
                 lg.add_color_stop_rgba(1, rgb[0], rgb[1], rgb[2], 0.0)
                 cr.set_source(lg)

--- a/gui/colors/bases.py
+++ b/gui/colors/bases.py
@@ -9,7 +9,7 @@
 
 """Base widgets for the colour selector module"""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 logger = logging.getLogger(__name__)

--- a/gui/colors/changers.py
+++ b/gui/colors/changers.py
@@ -11,7 +11,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gi.repository import GdkPixbuf
 from gi.repository import Gdk
@@ -62,18 +62,18 @@ class _CColorChanger (gui.colors.adjbases.IconRenderableColorAdjusterWidget):
         )
         arr = gdkpixbuf2numpy(pixbuf)
         self._backend.render(arr)
-        self._dx = (wd-size)/2
-        self._dy = (ht-size)/2
+        self._dx = (wd - size) // 2
+        self._dy = (ht - size) // 2
         cr.translate(self._dx, self._dy)
         Gdk.cairo_set_source_pixbuf(cr, pixbuf, 0, 0)
         cr.paint()
 
     def render_as_icon(self, cr, size):
         backend_size = float(self._backend.get_size())
-        scale = size/backend_size
-        cr.translate(size/2, size/2)
+        scale = size / backend_size
+        cr.translate(size // 2, size // 2)
         cr.scale(scale, scale)
-        cr.translate(-size/2, -size/2)
+        cr.translate(-size // 2, -size // 2)
         super(_CColorChanger, self).render_as_icon(cr, size)
 
     def get_color_at_position(self, x, y):

--- a/gui/colors/combined.py
+++ b/gui/colors/combined.py
@@ -14,7 +14,7 @@ gui.workspace instead of implementing this interface.
 
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from adjbases import ColorAdjuster
 

--- a/gui/colors/hcywheel.py
+++ b/gui/colors/hcywheel.py
@@ -726,7 +726,7 @@ class HCYMaskEditorWheel (HCYHueChromaWheel):
         psi = math.atan2(dy, dx) + (math.pi/nsides)
         psi += math.pi
         for i in xrange(nsides):
-            theta = 2.0 * math.pi * float(i)/nsides
+            theta = 2.0 * math.pi * i / nsides
             theta += psi
             px = int(x + size*math.cos(theta))
             py = int(y + size*math.sin(theta))

--- a/gui/colors/hcywheel.py
+++ b/gui/colors/hcywheel.py
@@ -11,7 +11,7 @@
 """Hue/Relative chroma/Luma adjuster widgets, with an editable gamut mask.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import math
 from copy import deepcopy

--- a/gui/colors/hsvcube.py
+++ b/gui/colors/hsvcube.py
@@ -159,7 +159,7 @@ class HSVCubeSlice (IconRenderableColorAdjusterWidget):
         eff_ht = int(ht - 2*b)
         f1, f2 = self.__get_faces()
 
-        step = max(1, int(float(eff_wd)/128))
+        step = max(1, int(eff_wd // 128))
 
         rect_x, rect_y = int(b)+0.5, int(b)+0.5
         rect_w, rect_h = int(eff_wd)-1, int(eff_ht)-1
@@ -167,7 +167,7 @@ class HSVCubeSlice (IconRenderableColorAdjusterWidget):
         # Paint the central area offscreen
         cr.push_group()
         for x in xrange(0, eff_wd, step):
-            amt = float(x)/eff_wd
+            amt = x / eff_wd
             setattr(col, f1, amt)
             setattr(col, f2, 1.0)
             lg = cairo.LinearGradient(b+x, b, b+x, b+eff_ht)

--- a/gui/colors/hsvcube.py
+++ b/gui/colors/hsvcube.py
@@ -11,7 +11,7 @@
 """Axis-aligned planar slice of an HSV color cube, and a depth slider.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gettext import gettext as _
 

--- a/gui/colors/hsvsquare.py
+++ b/gui/colors/hsvsquare.py
@@ -11,7 +11,7 @@
 """Axis-aligned planar slice of an HSV color cube, and a depth slider.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gettext import gettext as _
 
@@ -288,8 +288,8 @@ class _HSVSquareOuterRing (HueSaturationWheelAdjuster):
         col = HSVColor(color=self.get_managed_color())
         col.s = 1.0
         radius = self.get_radius(wd, ht, self.BORDER_WIDTH)
-        cx = int(wd/2)
-        cy = int(ht/2)
+        cx = int(wd // 2)
+        cy = int(ht // 2)
         cr.arc(cx, cy, radius+0.5, 0, 2*math.pi)
         cr.clip()
         x, y = self.get_pos_for_color(col)

--- a/gui/colors/hsvsquare.py
+++ b/gui/colors/hsvsquare.py
@@ -162,7 +162,7 @@ class _HSVSquareOuterRing (HueSaturationWheelAdjuster):
         cx, cy = self.get_center(alloc=alloc)
         # Normalized radius
         r = math.sqrt((x-cx)**2 + (y-cy)**2)
-        radius = float(self.get_radius(alloc=alloc))
+        radius = self.get_radius(alloc=alloc)
         if r > radius:
             r = radius
         r /= radius
@@ -229,7 +229,7 @@ class _HSVSquareOuterRing (HueSaturationWheelAdjuster):
         mgr = self.get_color_manager()
 
         for ih in xrange(steps+1):  # overshoot by 1, no solid bit for final
-            h = float(ih)/steps
+            h = ih / steps
             if mgr:
                 h = mgr.undistort_hue(h)
             edge_col = self.color_at_normalized_polar_pos(1.0, h)
@@ -243,7 +243,7 @@ class _HSVSquareOuterRing (HueSaturationWheelAdjuster):
                 x, y = cr.get_current_point()
                 cr.line_to(0, 0)
                 cr.close_path()
-                lg = cairo.LinearGradient(radius, 0, float(x+radius)/2, y)
+                lg = cairo.LinearGradient(radius, 0, (x + radius) / 2, y)
                 lg.add_color_stop_rgba(0, rgb[0], rgb[1], rgb[2], 1.0)
                 lg.add_color_stop_rgba(1, rgb[0], rgb[1], rgb[2], 0.0)
                 cr.set_source(lg)
@@ -338,7 +338,7 @@ class _HSVSquareInnerSquare (IconRenderableColorAdjusterWidget):
         eff_ht = int(ht - 2*b)
         f1, f2 = self.__get_faces()
 
-        step = max(1, int(float(eff_wd)/128))
+        step = max(1, int(eff_wd // 128))
 
         rect_x, rect_y = int(b)+0.5, int(b)+0.5
         rect_w, rect_h = int(eff_wd)-1, int(eff_ht)-1
@@ -346,7 +346,7 @@ class _HSVSquareInnerSquare (IconRenderableColorAdjusterWidget):
         # Paint the central area offscreen
         cr.push_group()
         for x in xrange(0, eff_wd, step):
-            amt = float(x)/eff_wd
+            amt = x / eff_wd
             setattr(col, f1, amt)
             setattr(col, f2, 1.0)
             lg = cairo.LinearGradient(b+x, b, b+x, b+eff_ht)

--- a/gui/colors/hsvwheel.py
+++ b/gui/colors/hsvwheel.py
@@ -10,7 +10,7 @@
 """Hue, Saturation and Value wheel.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gettext import gettext as _
 import math

--- a/gui/colors/paletteview.py
+++ b/gui/colors/paletteview.py
@@ -487,7 +487,7 @@ class _PalettePreview (Gtk.DrawingArea):
             if (s * ncolumns) > w:
                 ncolumns = 0
         if ncolumns == 0:
-            s = math.sqrt(float(w * h) / ncolors)
+            s = math.sqrt((w * h) / ncolors)
             s = clamp(s, s_min, s_max)
             s = int(s)
             ncolumns = max(1, int(w // s))
@@ -588,7 +588,7 @@ class _PaletteGridLayout (ColorAdjusterWidget):
         else:
             # Free-flowing
             if ncolors > 0:
-                size = int(math.sqrt(float(width * height) / ncolors))
+                size = int(math.sqrt((width * height) / ncolors))
                 size = self._constrain_swatch_size(size)
                 ncolumns = max(1, min(ncolors, width // size))
                 nrows = max(1, int(ncolors // ncolumns))

--- a/gui/colors/paletteview.py
+++ b/gui/colors/paletteview.py
@@ -16,7 +16,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import math
 import os
@@ -490,16 +490,16 @@ class _PalettePreview (Gtk.DrawingArea):
             s = math.sqrt(float(w * h) / ncolors)
             s = clamp(s, s_min, s_max)
             s = int(s)
-            ncolumns = max(1, int(w / s))
+            ncolumns = max(1, int(w // s))
         nrows = int(ncolors // ncolumns)
         if ncolors % ncolumns != 0:
             nrows += 1
         nrows = max(1, nrows)
         dx, dy = 0, 0
         if (nrows * s) < h:
-            dy = int(h - (nrows * s)) / 2
+            dy = int(h - (nrows * s)) // 2
         if (ncolumns * s) < w:
-            dx = int(w - (ncolumns * s)) / 2
+            dx = int(w - (ncolumns * s)) // 2
         bg_color = _widget_get_bg_color(self)
         _palette_render(self._palette, cr, rows=nrows, columns=ncolumns,
                         swatch_size=s, bg_color=bg_color,
@@ -590,16 +590,16 @@ class _PaletteGridLayout (ColorAdjusterWidget):
             if ncolors > 0:
                 size = int(math.sqrt(float(width * height) / ncolors))
                 size = self._constrain_swatch_size(size)
-                ncolumns = max(1, min(ncolors, width / size))
-                nrows = max(1, int(ncolors / ncolumns))
+                ncolumns = max(1, min(ncolors, width // size))
+                nrows = max(1, int(ncolors // ncolumns))
                 if int(ncolors % ncolumns) > 0:
                     nrows += 1
                 if nrows * size > height or ncolumns * size > width:
-                    size = max(1, min(int(height / nrows),
-                                      int(width / ncolumns)))
+                    size = max(1, min(int(height // nrows),
+                                      int(width // ncolumns)))
                     size = self._constrain_swatch_size(size)
-                    ncolumns = max(1, min(ncolors, width / size))
-                    nrows = max(1, int(ncolors / ncolumns))
+                    ncolumns = max(1, min(ncolors, width // size))
+                    nrows = max(1, int(ncolors // ncolumns))
                     if int(ncolors % ncolumns) > 0:
                         nrows += 1
             else:
@@ -908,7 +908,7 @@ class _PaletteGridLayout (ColorAdjusterWidget):
             ncolumns = int(ncolumns)
             if ncolors > 0:
                 ncolumns = min(ncolumns, ncolors)
-                nrows = max(1, int(ncolors / ncolumns))
+                nrows = max(1, int(ncolors // ncolumns))
                 if int(ncolors % ncolumns) > 0:
                     nrows += 1
             else:
@@ -947,14 +947,14 @@ class _PaletteGridLayout (ColorAdjusterWidget):
         ncolors, nrows, ncolumns = self._get_palette_dimensions()
         if nrows and ncolumns:
             # Horizontal fit
-            swatch_size = self._constrain_swatch_size(int(width / ncolumns))
+            swatch_size = self._constrain_swatch_size(int(width // ncolumns))
             min_h = self._SWATCH_SIZE_MIN * nrows
             nat_h = swatch_size * nrows
         else:
             # Free-flowing, across and then down
             # Since s = sqrt((w*h)/n),
-            min_h = int(((self._SWATCH_SIZE_MIN ** 2) * ncolors) / width)
-            nat_h = int(((self._SWATCH_SIZE_NOMINAL ** 2) * ncolors) / width)
+            min_h = int(((self._SWATCH_SIZE_MIN ** 2) * ncolors) // width)
+            nat_h = int(((self._SWATCH_SIZE_NOMINAL ** 2) * ncolors) // width)
         return min_h, max(min_h, nat_h)
 
     def do_get_preferred_height(self):
@@ -977,7 +977,7 @@ class _PaletteGridLayout (ColorAdjusterWidget):
         ncolors, nrows, ncolumns = self._get_palette_dimensions()
         if nrows and ncolumns:
             # Vertical fit
-            swatch_size = self._constrain_swatch_size(int(height / nrows))
+            swatch_size = self._constrain_swatch_size(int(height // nrows))
             min_w = self._SWATCH_SIZE_MIN * ncolumns
             nat_w = swatch_size * ncolumns
         else:
@@ -1069,7 +1069,7 @@ class _PaletteGridLayout (ColorAdjusterWidget):
         dx, dy = self.get_painting_offset()
         s_w = s_h = self._swatch_size
         c = i % self._columns
-        r = int(i / self._columns)
+        r = int(i // self._columns)
         x = 0.5 + (c * s_w)
         y = 0.5 + (r * s_h)
         return (x + dx, y + dy)
@@ -1463,8 +1463,8 @@ def _palette_render(palette, cr, rows, columns, swatch_size,
         cr.rectangle(s_x, s_y, s_w - 1, s_h - 1)
         cr.fill()
         if fill_fg_rgb is not None:
-            s_w2 = int((s_w - 1) / 2)
-            s_h2 = int((s_h - 1) / 2)
+            s_w2 = int((s_w - 1) // 2)
+            s_h2 = int((s_h - 1) // 2)
             cr.set_source_rgb(*fill_fg_rgb)
             cr.rectangle(s_x, s_y, s_w2, s_h2)
             cr.fill()

--- a/gui/colors/sliders.py
+++ b/gui/colors/sliders.py
@@ -10,7 +10,7 @@
 """Component sliders for power users.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -146,11 +146,11 @@ class ComponentSlidersAdjusterPage (CombinedAdjusterPage, IconRenderable):
             cr.restore()
         else:
             cr.save()
-            bar_ht = int(size/3)
-            offset = int((size - bar_ht*3) / 2)
+            bar_ht = int(size // 3)
+            offset = int((size - bar_ht*3) // 2)
             cr.translate(0, offset)
             for adj in adjs:
-                adj.BORDER_WIDTH = max(2, int(size/16))
+                adj.BORDER_WIDTH = max(2, int(size // 16))
                 adj.render_background_cb(cr, wd=size, ht=bar_ht)
                 cr.translate(0, bar_ht)
             cr.restore()
@@ -281,7 +281,7 @@ class HCYLumaSlider (SliderColorAdjuster):
         alloc = self.get_allocation()
         len = self.vertical and alloc.height or alloc.width
         len -= self.BORDER_WIDTH * 2
-        return min(int(len / 3), 64)
+        return min(int(len // 3), 64)
 
     def get_color_for_bar_amount(self, amt):
         col = HCYColor(color=self.get_managed_color())

--- a/gui/colors/uimisc.py
+++ b/gui/colors/uimisc.py
@@ -10,7 +10,7 @@
 """UI miscellanea.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gi.repository import Gtk
 

--- a/gui/colors/util.py
+++ b/gui/colors/util.py
@@ -10,7 +10,7 @@
 """Miscellaneous helpers & drawing utility functions for Cairo.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import cairo
 import math

--- a/gui/colors/util.py
+++ b/gui/colors/util.py
@@ -35,12 +35,10 @@ def add_distance_fade_stops(gr, rgb, nstops=3, gamma=2, alpha=1.0):
     seems to reduce halo artefacts on some LCD backlit displays.
     """
     red, green, blue = rgb
-    alpha = float(alpha)
-    gamma = float(gamma)
     nstops = int(nstops) + 2
     for s in xrange(nstops+1):
-        a = alpha * ((float(nstops-s)/nstops) ** gamma)
-        stop = float(s)/nstops
+        a = alpha * (((nstops - s) / nstops) ** gamma)
+        stop = s / nstops
         gr.add_color_stop_rgba(stop, red, green, blue, a)
 
 

--- a/gui/colortools.py
+++ b/gui/colortools.py
@@ -9,7 +9,7 @@
 
 """Dockable Workspace tools for color adjusters."""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import gi
 from gi.repository import Gtk

--- a/gui/cursor.py
+++ b/gui/cursor.py
@@ -5,7 +5,7 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-from __future__ import print_function
+from __future__ import division, print_function
 
 import gui.drawutils
 
@@ -96,7 +96,7 @@ def get_brush_cursor(radius, style, prefs={}):
         #
         # NOTE: is it worth adjusting the freehand drawing code to add half a
         # pixel to the position passed on to brushlib for the even case?
-        hot_x = hot_y = int(d/2)
+        hot_x = hot_y = int(d // 2)
 
         pixbuf = _image_surface_to_pixbuf(surf)
         last_cursor = Gdk.Cursor.new_from_pixbuf(display, pixbuf,
@@ -175,9 +175,9 @@ def draw_brush_cursor(cr, d, style=BRUSH_CURSOR_STYLE_NORMAL, prefs={}):
     # Pick centre to ensure pixel alignedness for the outer edge of the
     # black outline.
     if d % 2 == 0:
-        r0 = int(d/2)
+        r0 = int(d // 2)
     else:
-        r0 = int(d/2) + 0.5
+        r0 = int(d // 2) + 0.5
     cx = cy = r0
 
     # Outer "bg" line.
@@ -413,7 +413,8 @@ if __name__ == '__main__':
 
     for style in xrange(4):
         col = 0
-        for size in xrange(min_size, max_size+1, (max_size-min_size)/nsteps):
+        for size in xrange(min_size, max_size + 1,
+                           (max_size - min_size) // nsteps):
             cr.save()
             y = (style * max_size) + ((max_size - size)/2)
             x = (col * max_size) + ((max_size - size)/2)
@@ -433,7 +434,7 @@ if __name__ == '__main__':
 
     def _enter_cb(widget, event):
         global style, max_size
-        r = randint(3, max_size/2)
+        r = randint(3, max_size // 2)
         print("DEBUG: radius=%s, style=%s" % (r, style))
         cursor = get_brush_cursor(r, style)
         widget.get_window().set_cursor(cursor)

--- a/gui/curve.py
+++ b/gui/curve.py
@@ -87,8 +87,8 @@ class CurveWidget(Gtk.DrawingArea):
         x, y = event_x, event_y
         x -= RADIUS
         y -= RADIUS
-        x = float(x) / width
-        y = float(y) / height
+        x = x / width
+        y = y / height
         return (x, y)
 
     def get_display_area(self):

--- a/gui/curve.py
+++ b/gui/curve.py
@@ -6,7 +6,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from warnings import warn
 import logging

--- a/gui/device.py
+++ b/gui/device.py
@@ -10,7 +10,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 import collections

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -9,7 +9,7 @@
 """Common dialog functions"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import gi
 from gi.repository import Gtk

--- a/gui/displayfilter.py
+++ b/gui/displayfilter.py
@@ -11,7 +11,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import numpy as np
 

--- a/gui/document.py
+++ b/gui/document.py
@@ -17,7 +17,7 @@ i.e. they convert user input into updates to the document model.
 
 ## Imports
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import os.path

--- a/gui/drawutils.py
+++ b/gui/drawutils.py
@@ -13,7 +13,7 @@ See also: gui.style
 """
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 logger = logging.getLogger(__name__)
@@ -183,7 +183,7 @@ def render_brush_preview_pixbuf(brushinfo, max_edge_tiles=4):
         pixbuf = pixbuf.scale_simple(128, 128, interp)
     # Composite over a checquered bg via Cairo: shows erases
     size = gui.style.ALPHA_CHECK_SIZE
-    nchecks = int(128 / size)
+    nchecks = int(128 // size)
     cairo_surf = cairo.ImageSurface(cairo.FORMAT_ARGB32, 128, 128)
     cr = cairo.Context(cairo_surf)
     render_checks(cr, size, nchecks)

--- a/gui/drawwindow.py
+++ b/gui/drawwindow.py
@@ -14,7 +14,7 @@ Painting is done in tileddrawwidget.py.
 """
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import os.path

--- a/gui/externalapp.py
+++ b/gui/externalapp.py
@@ -12,7 +12,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 logger = logging.getLogger(__name__)

--- a/gui/factoryaction.py
+++ b/gui/factoryaction.py
@@ -9,7 +9,7 @@
 
 """Factory for creating custom toolbar and manu items via UIManager"""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from warnings import warn
 

--- a/gui/filehandling.py
+++ b/gui/filehandling.py
@@ -12,7 +12,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import re

--- a/gui/fill.py
+++ b/gui/fill.py
@@ -8,7 +8,7 @@
 """Flood fill tool"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import gi
 from gi.repository import Gtk

--- a/gui/footer.py
+++ b/gui/footer.py
@@ -10,7 +10,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import math
 import logging

--- a/gui/framewindow.py
+++ b/gui/framewindow.py
@@ -8,7 +8,7 @@
 """Frame manipulation mode and subwindow"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import math
 

--- a/gui/framewindow.py
+++ b/gui/framewindow.py
@@ -668,7 +668,7 @@ class FrameEditOptionsWidget (Gtk.Alignment):
     def _color_set_cb(self, colorbutton):
         color_gdk = colorbutton.get_color()
         r, g, b = uicolor.from_gdk_color(color_gdk).get_rgb()
-        a = float(colorbutton.get_alpha()) / 65535
+        a = colorbutton.get_alpha() / 65535
         self.app.preferences["frame.color_rgba"] = (r, g, b, a)
         self.app.doc.tdw.queue_draw()
 

--- a/gui/freehand.py
+++ b/gui/freehand.py
@@ -9,7 +9,7 @@
 """Freehand drawing modes"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import math
 from lib.helpers import clamp

--- a/gui/freehand.py
+++ b/gui/freehand.py
@@ -221,7 +221,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
                         interval = 100.0
                     else:
                         zt = self._last_queued_event_time
-                        interval = float(dtime)
+                        interval = dtime
                     step = interval / (len(self._zero_dtime_motions) + 1)
                     for zx, zy, zp, zxt, zyt in self._zero_dtime_motions:
                         zt += step
@@ -834,7 +834,7 @@ class PressureAndTiltInterpolator (object):
             for event in self._np:
                 t, x, y = event[0:3]
                 p, xt, yt = spline_4p(
-                    float(t - t0) / dt,
+                    (t - t0) / dt,
                     np.array(pt0p[3:]), np.array(pt0[3:]),
                     np.array(pt1[3:]), np.array(pt1n[3:])
                 )

--- a/gui/gtkexcepthook.py
+++ b/gui/gtkexcepthook.py
@@ -16,7 +16,7 @@
 # - fix lockup with dialog.run(), return to mainloop instead
 # see also http://faq.pygtk.org/index.py?req=show&file=faq20.010.htp
 # (The license is still whatever you want.)
-from __future__ import print_function
+from __future__ import division, print_function
 
 import inspect
 import linecache

--- a/gui/history.py
+++ b/gui/history.py
@@ -11,7 +11,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import gi
 from gi.repository import Gtk

--- a/gui/historypopup.py
+++ b/gui/historypopup.py
@@ -7,7 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gi.repository import Gtk
 from gi.repository import Gdk
@@ -24,7 +24,7 @@ import windowing
 
 popup_height = 60
 bigcolor_width = popup_height
-smallcolor_width = popup_height/2
+smallcolor_width = popup_height // 2
 
 
 ## Class definitions
@@ -93,8 +93,10 @@ class HistoryPopup (windowing.PopupWindow):
 
         # popup placement
         x, y = self.get_position()
-        bigcolor_center_x = self.selection * smallcolor_width + bigcolor_width/2
-        self.move(x + self.popup_width/2 - bigcolor_center_x, y + bigcolor_width)
+        bigcolor_center_x = (self.selection * smallcolor_width +
+                             bigcolor_width // 2)
+        self.move(x + self.popup_width // 2 - bigcolor_center_x,
+                  y + bigcolor_width)
         self.show_all()
 
         window = self.get_window()

--- a/gui/inktool.py
+++ b/gui/inktool.py
@@ -8,7 +8,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import math
 import collections

--- a/gui/inktool.py
+++ b/gui/inktool.py
@@ -471,8 +471,8 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         steps_t = dtime_p0_p1_real / self.INTERPOLATION_MAX_SLICE_TIME
         dist_p1_p2 = math.hypot(p1[0]-p2[0], p1[1]-p2[1])
         steps_d = dist_p1_p2 / self.INTERPOLATION_MAX_SLICE_DISTANCE
-        steps_max = float(self.INTERPOLATION_MAX_SLICES)
-        steps = math.ceil(min(steps_max, max([2, steps_t, steps_d])))
+        steps = math.ceil(min(self.INTERPOLATION_MAX_SLICES,
+                              max(2, steps_t, steps_d)))
         for i in xrange(int(steps) + 1):
             t = i / steps
             point = gui.drawutils.spline_4p(t, p_1, p0, p1, p2)

--- a/gui/inputtestwindow.py
+++ b/gui/inputtestwindow.py
@@ -7,7 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 logger = logging.getLogger(__name__)

--- a/gui/keyboard.py
+++ b/gui/keyboard.py
@@ -15,7 +15,7 @@ for consistent keyboard handling.
 
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 logger = logging.getLogger(__name__)

--- a/gui/layermanip.py
+++ b/gui/layermanip.py
@@ -9,7 +9,7 @@
 """Modes for moving layers around on the canvas"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gettext import gettext as _
 

--- a/gui/layermodes.py
+++ b/gui/layermodes.py
@@ -10,7 +10,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gi.repository import Gtk
 

--- a/gui/layers.py
+++ b/gui/layers.py
@@ -10,7 +10,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import lib.layer
 import lib.xml

--- a/gui/layerswindow.py
+++ b/gui/layerswindow.py
@@ -11,7 +11,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gettext import gettext as _
 import os.path

--- a/gui/linemode.py
+++ b/gui/linemode.py
@@ -15,7 +15,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import math
 import logging

--- a/gui/main.py
+++ b/gui/main.py
@@ -10,7 +10,7 @@
 """Command-line handling - traditional main() function."""
 
 ## Imports (nothing involving mypaintlib at this point)
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import sys

--- a/gui/meta.py
+++ b/gui/meta.py
@@ -16,7 +16,7 @@ See also `lib.meta`.
 """
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import sys
 import os

--- a/gui/mode.py
+++ b/gui/mode.py
@@ -9,7 +9,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 logger = logging.getLogger(__name__)

--- a/gui/objfactory.py
+++ b/gui/objfactory.py
@@ -9,7 +9,7 @@
 """String and tuple-based construction and reconstruction of objects."""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 logger = logging.getLogger(__name__)

--- a/gui/optionspanel.py
+++ b/gui/optionspanel.py
@@ -9,7 +9,7 @@
 """Dockable panel showing options for the current mode"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import workspace
 import lib.xml

--- a/gui/overlays.py
+++ b/gui/overlays.py
@@ -10,7 +10,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 from math import pi
 from gettext import gettext as _
@@ -91,7 +91,7 @@ class FadingOverlay (Overlay):
         """Restart if not currently running, without changing the alpha.
         """
         if self.__anim_srcid is None:
-            delay = int(1000 / self.fade_fps)
+            delay = int(1000 // self.fade_fps)
             self.__anim_srcid = GLib.timeout_add(delay, self.anim_cb)
 
     def stop_anim(self):

--- a/gui/overlays.py
+++ b/gui/overlays.py
@@ -76,7 +76,7 @@ class FadingOverlay (Overlay):
         Each step fades the alpha multiplier slightly and invalidates the area
         last painted.
         """
-        self.alpha -= 1.0 / (float(self.fade_fps) * self.fade_duration)
+        self.alpha -= 1 / (self.fade_fps * self.fade_duration)
         self.alpha = clamp(self.alpha, 0.0, 1.0)
 
         if self.__area:

--- a/gui/picker.py
+++ b/gui/picker.py
@@ -16,7 +16,7 @@ with a rather wide scope.
 """
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gui.tileddrawwidget import TiledDrawWidget
 from gui.document import Document

--- a/gui/pixbuflist.py
+++ b/gui/pixbuflist.py
@@ -240,7 +240,7 @@ class PixbufList(Gtk.DrawingArea):
             height = self.pixbuf.get_height()
         width = max(width, self.total_w)
         self.tiles_w = max(1, int(width // self.total_w))
-        self.tiles_h = max(1, int(ceil(float(len(self.itemlist)) / self.tiles_w)))
+        self.tiles_h = max(1, int(ceil(len(self.itemlist) / self.tiles_w)))
 
         height = self.tiles_h * self.total_h
         #self.set_size_request(-1, -1)

--- a/gui/pixbuflist.py
+++ b/gui/pixbuflist.py
@@ -7,7 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from warnings import warn
 from math import ceil
@@ -239,7 +239,7 @@ class PixbufList(Gtk.DrawingArea):
             width = self.pixbuf.get_width()
             height = self.pixbuf.get_height()
         width = max(width, self.total_w)
-        self.tiles_w = max(1, int(width / self.total_w))
+        self.tiles_w = max(1, int(width // self.total_w))
         self.tiles_h = max(1, int(ceil(float(len(self.itemlist)) / self.tiles_w)))
 
         height = self.tiles_h * self.total_h
@@ -253,7 +253,7 @@ class PixbufList(Gtk.DrawingArea):
         self.pixbuf.fill(0xffffff00)  # transparent
         for i, item in enumerate(self.itemlist):
             x = (i % self.tiles_w) * self.total_w
-            y = (i / self.tiles_w) * self.total_h
+            y = (i // self.tiles_w) * self.total_h
             x += self.total_border
             y += self.total_border
 
@@ -273,12 +273,12 @@ class PixbufList(Gtk.DrawingArea):
 
     def index(self, x, y):
         x, y = int(x), int(y)
-        i = x / self.total_w
+        i = x // self.total_w
         if i >= self.tiles_w:
             i = self.tiles_w - 1
         if i < 0:
             i = 0
-        i = i + self.tiles_w * (y / self.total_h)
+        i = i + self.tiles_w * (y // self.total_h)
         if i < 0:
             i = 0
         return i
@@ -356,7 +356,7 @@ class PixbufList(Gtk.DrawingArea):
             if rect_color is None:
                 continue
             x = (i % self.tiles_w) * self.total_w
-            y = (i / self.tiles_w) * self.total_h
+            y = (i // self.tiles_w) * self.total_h
             w = self.total_w
             h = self.total_h
 

--- a/gui/preferenceswindow.py
+++ b/gui/preferenceswindow.py
@@ -9,7 +9,7 @@
 """Preferences dialog.
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os.path
 from logging import getLogger

--- a/gui/previewwindow.py
+++ b/gui/previewwindow.py
@@ -7,7 +7,7 @@
 # (at your option) any later version.
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import math
 import bisect

--- a/gui/previewwindow.py
+++ b/gui/previewwindow.py
@@ -485,7 +485,7 @@ class PreviewTool (SizedVBoxToolWidget):
         """Updates the viewport overlay's position"""
         alloc = self._main_tdw.get_allocation()
         x, y = 0., 0.
-        w, h = float(alloc.width), float(alloc.height)
+        w, h = alloc.width, alloc.height
         # List of viewport corners
         nw = w/4*PHI
         nh = h/4*PHI
@@ -646,8 +646,8 @@ class PreviewTool (SizedVBoxToolWidget):
         # Scale to fit within a rectangle slightly smaller than the widget.
         # Slight borders are nice.
         border = 12
-        zoom_x = (float(alloc.width) - border) / w
-        zoom_y = (float(alloc.height) - border) / h
+        zoom_x = (alloc.width - border) / w
+        zoom_y = (alloc.height - border) / h
 
         # Set the preview canvas's size and scale
         scale = self._limit_scale(min(zoom_x, zoom_y))

--- a/gui/profiling.py
+++ b/gui/profiling.py
@@ -8,7 +8,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import time

--- a/gui/quickchoice.py
+++ b/gui/quickchoice.py
@@ -9,7 +9,7 @@
 """Widgets and popup dialogs for making quick choices"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import abc
 

--- a/gui/scratchwindow.py
+++ b/gui/scratchwindow.py
@@ -10,7 +10,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import logging

--- a/gui/spinbox.py
+++ b/gui/spinbox.py
@@ -5,7 +5,7 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gettext import gettext as _
 

--- a/gui/stategroup.py
+++ b/gui/stategroup.py
@@ -7,7 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 logger = logging.getLogger(__name__)

--- a/gui/style.py
+++ b/gui/style.py
@@ -16,7 +16,7 @@ See also: gui.drawutils
 
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from lib.color import HCYColor, RGBColor
 

--- a/gui/symmetry.py
+++ b/gui/symmetry.py
@@ -8,7 +8,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import cairo
 import math

--- a/gui/tileddrawwidget.py
+++ b/gui/tileddrawwidget.py
@@ -9,7 +9,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import random
@@ -742,7 +742,7 @@ class CanvasRenderer (Gtk.DrawingArea, DrawCursorMixin):
         assert tiledsurface.N % gui.style.ALPHA_CHECK_SIZE == 0
         N = tiledsurface.N
         size = gui.style.ALPHA_CHECK_SIZE
-        nchecks = int(N / size)
+        nchecks = int(N // size)
         cairo_surf = cairo.ImageSurface(cairo.FORMAT_ARGB32, N, N)
         cr = cairo.Context(cairo_surf)
         render_checks(cr, size, nchecks)
@@ -975,7 +975,7 @@ class CanvasRenderer (Gtk.DrawingArea, DrawCursorMixin):
         size = max(1, int(size))
 
         # Extract a square Cairo surface containing the area to sample
-        r = int(size/2)
+        r = int(size // 2)
         x = int(x) - r
         y = int(y) - r
         surf = self._new_image_surface_from_visible_area(
@@ -1171,7 +1171,7 @@ class CanvasRenderer (Gtk.DrawingArea, DrawCursorMixin):
         # determine whether the render is "sparse", [TODO: define what this
         # means]
         x, y, w, h = device_bbox
-        cx, cy = x+w/2, y+h/2
+        cx, cy = x + w // 2, y + h // 2
 
         # As of 2012-07-08, Ubuntu Precise (LTS, unfortunately) and Debian
         # unstable(!) use python-cairo 1.8.8, which does not support

--- a/gui/toolbar.py
+++ b/gui/toolbar.py
@@ -10,7 +10,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 from gettext import gettext as _

--- a/gui/topbar.py
+++ b/gui/topbar.py
@@ -9,7 +9,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import math

--- a/gui/uicolor.py
+++ b/gui/uicolor.py
@@ -34,7 +34,7 @@ def from_gdk_color(gdk_color):
 
     """
     rgb16 = (gdk_color.red, gdk_color.green, gdk_color.blue)
-    return RGBColor(*[float(c)/65535 for c in rgb16])
+    return RGBColor(*[c / 65535 for c in rgb16])
 
 
 def to_gdk_color(color):
@@ -79,7 +79,7 @@ def from_drag_data(bytes):
     The data format is 8 bytes, RRGGBBAA, with assumed native endianness.
     Alpha is ignored.
     """
-    r, g, b, a = [float(h)/0xffff for h in struct.unpack("=HHHH", bytes)]
+    r, g, b, a = [h / 0xffff for h in struct.unpack("=HHHH", bytes)]
     return RGBColor(r, g, b)
     # TODO: check endianness
 

--- a/gui/uicolor.py
+++ b/gui/uicolor.py
@@ -16,7 +16,7 @@ They can't be part of lib/ because of the GDK dependency.
 
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import struct
 

--- a/gui/viewmanip.py
+++ b/gui/viewmanip.py
@@ -10,7 +10,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import gui.mode
 

--- a/gui/widgets.py
+++ b/gui/widgets.py
@@ -8,7 +8,7 @@
 
 """Layout constants and constructor functions for common widgets."""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import gi
 from gi.repository import Gtk

--- a/gui/windowing.py
+++ b/gui/windowing.py
@@ -10,7 +10,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import sys
 import os.path

--- a/gui/workspace.py
+++ b/gui/workspace.py
@@ -9,7 +9,7 @@
 """Workspaces with a central canvas, sidebars and saved layouts"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 from warnings import warn

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,3 +1,3 @@
 
-from __future__ import print_function
+from __future__ import division, print_function
 

--- a/lib/alg.py
+++ b/lib/alg.py
@@ -10,7 +10,7 @@
 """Miscellaneous little algorithms"""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 from math import sqrt
 

--- a/lib/autosave.py
+++ b/lib/autosave.py
@@ -9,7 +9,7 @@
 
 """Autosave/autorecover interface"""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import abc
 import uuid

--- a/lib/brush.py
+++ b/lib/brush.py
@@ -5,7 +5,7 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-from __future__ import print_function
+from __future__ import division, print_function
 
 import mypaintlib
 import helpers

--- a/lib/brushes_migrate_json.py
+++ b/lib/brushes_migrate_json.py
@@ -6,7 +6,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import sys
 import os

--- a/lib/brushsettings.py
+++ b/lib/brushsettings.py
@@ -11,7 +11,7 @@
 
 
 # Imports:
-from __future__ import print_function
+from __future__ import division, print_function
 
 import mypaintlib as _mypaintlib
 

--- a/lib/cache.py
+++ b/lib/cache.py
@@ -6,7 +6,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from collections import OrderedDict
 

--- a/lib/color.py
+++ b/lib/color.py
@@ -21,7 +21,7 @@ with an adjuster does its type change to match the control's color space.
 """
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import re
 import colorsys

--- a/lib/color.py
+++ b/lib/color.py
@@ -248,9 +248,9 @@ class UIColor (object):
                 r += ord(data[offs])
                 g += ord(data[offs+1])
                 b += ord(data[offs+2])
-        r = float(r) / n_pixels
-        g = float(g) / n_pixels
-        b = float(b) / n_pixels
+        r = r / n_pixels
+        g = g / n_pixels
+        b = b / n_pixels
         return RGBColor(r/255, g/255, b/255)
 
     def interpolate(self, other, steps):
@@ -309,7 +309,7 @@ class RGBColor (UIColor):
         assert steps >= 3
         other = RGBColor(color=other)
         for step in xrange(steps):
-            p = float(step) / (steps - 1)
+            p = step / (steps - 1)
             r = self.r + (other.r - self.r) * p
             g = self.g + (other.g - self.g) * p
             b = self.b + (other.b - self.b) * p
@@ -423,7 +423,7 @@ class HSVColor (UIColor):
                 hdelta = hdx0
         # Interpolate, using shortest angular dist for hue
         for step in xrange(steps):
-            p = float(step) / (steps - 1)
+            p = step / (steps - 1)
             h = (self.h + hdelta * p) % 1.0
             s = self.s + (other.s - self.s) * p
             v = self.v + (other.v - self.v) * p
@@ -569,7 +569,7 @@ class HCYColor (UIColor):
             if abs(hdx0) < abs(hdelta):
                 hdelta = hdx0
         for step in xrange(steps):
-            p = float(step) / (steps - 1)
+            p = step / (steps - 1)
             h = (self.h + hdelta * p) % 1.0
             c = self.c + (other.c - self.c) * p
             y = self.y + (other.y - self.y) * p
@@ -683,7 +683,7 @@ class YCbCrColor (UIColor):
         other = YCbCrColor(color=other)
         # Like HSV, interpolate using the shortest angular distance.
         for step in xrange(steps):
-            p = float(step) / (steps - 1)
+            p = step / (steps - 1)
             Y = self.Y + (other.Y - self.Y) * p
             Cb = self.Cb + (other.Cb - self.Cb) * p
             Cr = self.Cr + (other.Cr - self.Cr) * p

--- a/lib/command.py
+++ b/lib/command.py
@@ -8,7 +8,7 @@
 # (at your option) any later version.
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import lib.layer
 import helpers

--- a/lib/document.py
+++ b/lib/document.py
@@ -9,7 +9,7 @@
 
 ## Imports
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 import sys

--- a/lib/errors.py
+++ b/lib/errors.py
@@ -9,7 +9,7 @@
 
 """Error classes which may be raised by gui-independent code"""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 
 class FileHandlingError (Exception):

--- a/lib/fileutils.py
+++ b/lib/fileutils.py
@@ -12,7 +12,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 from math import floor, ceil, isnan
 import os

--- a/lib/gettext.py
+++ b/lib/gettext.py
@@ -24,7 +24,7 @@ still uses a relative import, however.
 
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, division, print_function
 
 from warnings import warn
 from gi.repository import GLib

--- a/lib/gichecks.py
+++ b/lib/gichecks.py
@@ -13,7 +13,7 @@ warning messages.
 
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import gi
 gi.require_version('GdkPixbuf', '2.0')

--- a/lib/glib.py
+++ b/lib/glib.py
@@ -17,7 +17,7 @@ unicode, and may not even be UTF-8). This module works around that.
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import sys
 import logging

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -392,7 +392,7 @@ def get_pixbuf(filename):
 
 def scale_proportionally(pixbuf, w, h, shrink_only=True):
     width, height = pixbuf.get_width(), pixbuf.get_height()
-    scale = min(w / float(width), h / float(height))
+    scale = min(w / width, h / height)
     if shrink_only and scale >= 1:
         return pixbuf
     new_width, new_height = int(width * scale), int(height * scale)

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -7,7 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from math import floor, isnan
 import os
@@ -414,9 +414,9 @@ def pixbuf_thumbnail(src, w, h, alpha=False):
         dst.fill(0xffffffff)  # white background
     src2.composite(
         dst,
-        (w - w2) / 2, (h - h2) / 2,
+        (w - w2) // 2, (h - h2) // 2,
         w2, h2,
-        (w - w2) / 2, (h - h2) / 2,
+        (w - w2) // 2, (h - h2) // 2,
         1, 1,
         GdkPixbuf.InterpType.BILINEAR,
         255,
@@ -508,9 +508,9 @@ def fmt_time_period_abbr(t):
     """
     if t < 0:
         raise ValueError("Parameter t cannot be negative")
-    days = int(t / (24 * 60 * 60))
-    hours = int(t - days * 24 * 60 * 60) / (60 * 60)
-    minutes = int(t - hours * 60 * 60) / 60
+    days = int(t // (24 * 60 * 60))
+    hours = int(t - days * 24 * 60 * 60) // (60 * 60)
+    minutes = int(t - hours * 60 * 60) // 60
     seconds = int(t - minutes * 60)
     # TRANSLATORS: I'm assuming that time periods in places where
     # TRANSLATORS: abbreviations make sense don't need ngettext()

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -14,7 +14,7 @@ Stolen from QuodLibet (thanks, lazka!) <https://github.com/quodlibet
 
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import sys

--- a/lib/idletask.py
+++ b/lib/idletask.py
@@ -10,7 +10,7 @@
 
 """Non-threaded, prioritizable background processing."""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import collections
 

--- a/lib/layer/__init__.py
+++ b/lib/layer/__init__.py
@@ -28,7 +28,7 @@ These can be listened to via the root layer stack.
 
 """
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from .group import *
 from .data import *

--- a/lib/layer/core.py
+++ b/lib/layer/core.py
@@ -10,7 +10,7 @@
 """Core layer classes etc."""
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import re
 import zlib

--- a/lib/layer/data.py
+++ b/lib/layer/data.py
@@ -11,7 +11,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import zlib
 import logging

--- a/lib/layer/error.py
+++ b/lib/layer/error.py
@@ -10,7 +10,7 @@
 
 """Exception classes"""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 
 class LoadingFailed (Exception):

--- a/lib/layer/group.py
+++ b/lib/layer/group.py
@@ -11,7 +11,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import logging
 logger = logging.getLogger(__name__)
@@ -585,7 +585,7 @@ class LayerStackMove (object):
             move.cleanup()
 
     def process(self, n=200):
-        n = max(20, int(n / len(self._moves)))
+        n = max(20, int(n // len(self._moves)))
         incomplete = False
         for move in self._moves:
             incomplete = move.process(n=n) or incomplete

--- a/lib/layer/test.py
+++ b/lib/layer/test.py
@@ -7,7 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 
 def make_test_stack():

--- a/lib/layer/tree.py
+++ b/lib/layer/tree.py
@@ -11,7 +11,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gi.repository import GdkPixbuf
 
@@ -320,7 +320,7 @@ class RootLayerStack (group.LayerStack):
         while (mipmap_level < tiledsurface.MAX_MIPMAP_LEVEL and
                max(w, h) >= 512):
             mipmap_level += 1
-            x, y, w, h = x/2, y/2, w/2, h/2
+            x, y, w, h = x // 2, y // 2, w // 2, h // 2
         w = max(1, w)
         h = max(1, h)
         pixbuf = self.render_as_pixbuf(x, y, w, h,

--- a/lib/meta.py
+++ b/lib/meta.py
@@ -94,7 +94,7 @@ artefacts.
 .. _Semantic Versioning: http://semver.org/
 
 """
-from __future__ import print_function
+from __future__ import division, print_function
 
 
 #: Program name, for display.

--- a/lib/modes.py
+++ b/lib/modes.py
@@ -8,7 +8,7 @@
 
 """Layer mode constants"""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gettext import gettext as _
 import lib.mypaintlib

--- a/lib/observable.py
+++ b/lib/observable.py
@@ -9,7 +9,7 @@
 
 """Observable method calls and C#-like syntactic sugar for events."""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import weakref
 import sys

--- a/lib/palette.py
+++ b/lib/palette.py
@@ -13,7 +13,7 @@
 
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import re
 import os

--- a/lib/palette.py
+++ b/lib/palette.py
@@ -178,9 +178,9 @@ class Palette (object):
                 continue
             r, g, b, col_name = match.groups()
             col_name = col_name.strip()
-            r = float(clamp(int(r), 0, 0xff))/0xff
-            g = float(clamp(int(g), 0, 0xff))/0xff
-            b = float(clamp(int(b), 0, 0xff))/0xff
+            r = clamp(int(r), 0, 0xff) / 0xff
+            g = clamp(int(g), 0, 0xff) / 0xff
+            b = clamp(int(b), 0, 0xff) / 0xff
             if r == g == b == 0 and col_name == self._EMPTY_SLOT_NAME:
                 self.append(None)
             else:

--- a/lib/pixbuf.py
+++ b/lib/pixbuf.py
@@ -19,7 +19,7 @@ which are exposed on POSIX platforms.
 """
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gi.repository import GdkPixbuf
 

--- a/lib/pixbufsurface.py
+++ b/lib/pixbufsurface.py
@@ -7,7 +7,7 @@
 # (at your option) any later version.
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import sys
 import contextlib
@@ -58,12 +58,12 @@ class Surface (TileAccessible, TileBlittable):
         # Variables ex, ey, ew, eh and epixbuf store the enlarged version.
         self.x, self.y, self.w, self.h = x, y, w, h
         #print x, y, w, h
-        tx = self.tx = x/N
-        ty = self.ty = y/N
+        tx = self.tx = x // N
+        ty = self.ty = y // N
         self.ex = tx*N
         self.ey = ty*N
-        tw = (x+w-1)/N - tx + 1
-        th = (y+h-1)/N - ty + 1
+        tw = (x + w - 1) // N - tx + 1
+        th = (y + h - 1) // N - ty + 1
 
         self.ew = tw*N
         self.eh = th*N

--- a/lib/stroke.py
+++ b/lib/stroke.py
@@ -6,7 +6,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import numpy as np
 
@@ -91,7 +91,7 @@ class Stroke (object):
         version, data = self.stroke_data[0], self.stroke_data[1:]
         assert version == '2'
         data = np.fromstring(data, dtype='float64')
-        data.shape = (len(data)/6, 6)
+        data.shape = (len(data) // 6, 6)
 
         surface.begin_atomic()
         for dtime, x, y, pressure, xtilt, ytilt in data:

--- a/lib/strokemap.py
+++ b/lib/strokemap.py
@@ -8,7 +8,7 @@
 # (at your option) any later version.
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import time
 import struct
@@ -155,7 +155,7 @@ class StrokeShape (object):
         """
         x = int(x)
         y = int(y)
-        pixel_ti = (x/N, y/N)
+        pixel_ti = (x // N, y // N)
         pred = lambda ti: (ti == pixel_ti)
         self._complete_tile_tasks(pred)
         tile = self.strokemap.get(pixel_ti)
@@ -463,9 +463,9 @@ class _Tile:
         else:
             array = self.to_array()
             rgba[:, :, 3] = array.astype('uint16') * _a
-            rgba[:, :, 0] = rgba[:, :, 3]/2
-            rgba[:, :, 1] = rgba[:, :, 3]/2
-            rgba[:, :, 2] = rgba[:, :, 3]/2
+            rgba[:, :, 0] = rgba[:, :, 3] // 2
+            rgba[:, :, 1] = rgba[:, :, 3] // 2
+            rgba[:, :, 2] = rgba[:, :, 3] // 2
 
     def __str__(self):
         return self.to_string()
@@ -541,8 +541,8 @@ class _TileIndexPredicate (object):
         self._center_tile = None
         self._max_tile_dist = None
         if center and radius:
-            self._center_tile = (center[0]/N, center[1]/N)
-            self._max_tile_dist = max(1, radius/N)
+            self._center_tile = (center[0] // N, center[1] // N)
+            self._max_tile_dist = max(1, radius // N)
         self.hits = set()
         self._maxhits = maxhits
 

--- a/lib/surface.py
+++ b/lib/surface.py
@@ -10,7 +10,7 @@
 
 """Common interfaces & routines for surface and surface-like objects"""
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import abc
 import contextlib
@@ -205,10 +205,10 @@ def scanline_strips_iter(surface, rect, alpha=False,
     assert h > 0
 
     # calculate bounding box in full tiles
-    render_tx = x/N
-    render_ty = y/N
-    render_tw = (x+w-1)/N - render_tx + 1
-    render_th = (y+h-1)/N - render_ty + 1
+    render_tx = x // N
+    render_ty = y // N
+    render_tw = (x + w - 1) // N - render_tx + 1
+    render_th = (y + h - 1) // N - render_ty + 1
 
     # buffer for rendering one tile row at a time
     arr = np.empty((N, render_tw * N, 4), 'uint8')  # rgba or rgbu

--- a/lib/xml.py
+++ b/lib/xml.py
@@ -12,7 +12,7 @@
 
 ## Imports
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, division, print_function
 
 import xml.etree.ElementTree as _ET
 

--- a/svg/symbolic-icons-extract.py
+++ b/svg/symbolic-icons-extract.py
@@ -10,7 +10,7 @@
 # usage: python symbolic-icons-extract.py [GROUP_ID(s)]
 
 ## Imports
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import sys

--- a/tests/guicontrol.py
+++ b/tests/guicontrol.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+from __future__ import division, print_function
 
 from gi.repository import Gtk, GObject
 import traceback

--- a/tests/test_compositeops.py
+++ b/tests/test_compositeops.py
@@ -2,7 +2,7 @@
 # Tests the layer compositing/blending code for correctness of its
 # advertized optimization flags.
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import sys

--- a/tests/test_memory_leak.py
+++ b/tests/test_memory_leak.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from time import time
 import sys

--- a/tests/test_mypaintlib.py
+++ b/tests/test_mypaintlib.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 from time import time
 import sys
@@ -36,25 +36,25 @@ def layerModes():
     dst = np.zeros((N, N, 4), 'uint16')  # rgbu
     dst_values = []
     r1 = range(0, 20)
-    r2 = range((1 << 15)/2-10, (1 << 15)/2+10)
+    r2 = range((1 << 15) // 2 - 10, (1 << 15) // 2 + 10)
     r3 = range((1 << 15)-19, (1 << 15)+1)
     dst_values = r1 + r2 + r3
 
     src = np.zeros((N, N, 4), 'int64')
     alphas = np.hstack((
-        np.arange(N/4),                     # low alpha
-        (1 << 15)/2 - np.arange(N/4),       # 50% alpha
-        (1 << 15) - np.arange(N/4),         # high alpha
-        np.randint((1 << 15)+1, size=N/4),  # random alpha
+        np.arange(N // 4),                       # low alpha
+        (1 << 15) // 2 - np.arange(N // 4),      # 50% alpha
+        (1 << 15) - np.arange(N // 4),           # high alpha
+        np.randint((1 << 15) + 1, size=N // 4),  # random alpha
         ))
     #plot(alphas); show()
     src[:, :, 3] = alphas.reshape(N, 1)  # alpha changes along y axis
 
     src[:, :, 0] = alphas  # red
-    src[:, N*0/4:N*1/4, 0] = np.arange(N/4)  # dark colors
-    src[:, N*1/4:N*2/4, 0] = alphas[N*1/4:N*2/4]/2 + np.arange(N/4) - N/2  # 50% lightness
-    src[:, N*2/4:N*3/4, 0] = alphas[N*2/4:N*3/4] - np.arange(N/4)  # bright colors
-    src[:, N*3/4:N*4/4, 0] = alphas[N*3/4:N*4/4] * np.random(N/4)  # random colors
+    # 50% lightness
+    src[:, N // 4 * 1:N // 4 * 2, 0] += np.arange(N // 4) - N // 2
+    src[:, N // 4 * 2:N // 4 * 3, 0] -= np.arange(N // 4)  # bright colors
+    src[:, N // 4 * 3:N // 4 * 4, 0] *= np.random(N // 4)  # random colors
     # clip away colors that are not possible due to low alpha
     src[:, :, 0] = np.minimum(src[:, :, 0], src[:, :, 3]).clip(0, 1 << 15)
     src = src.astype('uint16')
@@ -217,7 +217,7 @@ def docPaint():
     doc = document.Document(b)
     doc.undo()  # nop
     events = np.loadtxt('painting30sec.dat')
-    events = events[:len(events)/8]
+    events = events[:len(events) // 8]
     t_old = events[0][0]
     n = len(events)
     layer = doc.layer_stack.current

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+from __future__ import division, print_function
 
 import sys
 import os
@@ -126,7 +126,7 @@ def layerpaint_nozoom(gui):
     gui.wait_for_idle()
     gui.app.filehandler.open_file('bigimage.ora')
     gui_doc = gui.app.doc
-    gui_doc.model.select_layer(index=len(gui_doc.model.layer_stack)/2)
+    gui_doc.model.select_layer(index=len(gui_doc.model.layer_stack) // 2)
     for res in paint(gui):
         yield res
 
@@ -137,7 +137,7 @@ def layerpaint_zoomed_out_5x(gui):
     gui_doc = gui.app.doc
     gui.app.filehandler.open_file('bigimage.ora')
     gui_doc.tdw.scroll(800, 1000)
-    gui_doc.model.select_layer(index=len(gui_doc.model.layer_stack)/3)
+    gui_doc.model.select_layer(index=len(gui_doc.model.layer_stack) // 3)
     gui.zoom_out(5)
     for res in paint(gui):
         yield res

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -82,7 +82,7 @@ def test_scroll(
     nframes = 0
     for turn_i in xrange(turns):
         for step_i in xrange(turn_steps):
-            t = 2 * math.pi * (float(step_i)/turn_steps)
+            t = 2 * math.pi * (step_i / turn_steps)
             x = cx + math.cos(t) * radius
             y = cy + math.sin(t) * radius
             dx = x - last_x

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 import sys


### PR DESCRIPTION
On Python 3, division returns floats, while `//` returns integers. In cases where there are explicit casts to `float`, or `float` literals, I have left the plain `/`. In cases where there are explicit casts to `int`, I've changed it to `//`.

I also assumed that bboxes, widths, and heights are all integers and used `//`, but if that's not the case, I can re-check those cases.

I'll add a few comments where I'm not sure.
