### PR TITLE
Ensure open files are closed using context managers

### DIFF
--- a/desktop/mypaint-ora-thumbnailer.py
+++ b/desktop/mypaint-ora-thumbnailer.py
@@ -34,7 +34,8 @@ def ora_thumbnail(infile, outfile, size):
     """Extracts an OpenRaster file's thumbnail to PNG, with scaling."""
 
     # Extract a GdkPixbuf from the OpenRaster file
-    png_data = zipfile.ZipFile(infile).read('Thumbnails/thumbnail.png')
+    with zipfile.ZipFile(infile) as zf:
+        png_data = zf.read('Thumbnails/thumbnail.png')
     loader = GdkPixbuf.PixbufLoader()
     loader.write(png_data)
     loader.close()

--- a/gui/application.py
+++ b/gui/application.py
@@ -420,9 +420,8 @@ class Application (object):
         self.filehandler.save_scratchpad(self.scratchpad_filename)
         settingspath = join(self.user_confpath, 'settings.json')
         jsonstr = helpers.json_dumps(self.preferences)
-        f = open(settingspath, 'w')
-        f.write(jsonstr)
-        f.close()
+        with open(settingspath, 'w') as f:
+            f.write(jsonstr)
 
     def apply_settings(self):
         """Applies the current settings.
@@ -442,7 +441,8 @@ class Application (object):
         """
         def get_json_config():
             settingspath = join(self.user_confpath, 'settings.json')
-            jsonstr = open(settingspath).read()
+            with open(settingspath) as fp:
+                jsonstr = fp.read()
             try:
                 return helpers.json_loads(jsonstr)
             except Exception as e:

--- a/gui/brusheditor.py
+++ b/gui/brusheditor.py
@@ -140,9 +140,8 @@ class BrushEditorWindow (SubWindow):
         """Builds the UI from ``brusheditor.glade``"""
         ui_dir = os.path.dirname(os.path.abspath(__file__))
         ui_path = os.path.join(ui_dir, self._UI_DEFINITION_FILE)
-        ui_fp = open(ui_path, 'r')
-        ui_xml = ui_fp.read()
-        ui_fp.close()
+        with open(ui_path, 'r') as ui_fp:
+            ui_xml = ui_fp.read()
         self._builder.add_from_string(ui_xml)
         self._populate_inputs(ui_xml)
         self._populate_settings_treestore()

--- a/gui/brushmanager.py
+++ b/gui/brushmanager.py
@@ -489,160 +489,160 @@ class BrushManager (object):
 
         """
 
-        zip = zipfile.ZipFile(path)
-        names = zip.namelist()
-        # zipfile does utf-8 decoding on its own; this is just to make
-        # sure we have only unicode objects as brush names.
-        names = [s.decode('utf-8') for s in names]
+        with zipfile.ZipFile(path) as zf:
+            names = zf.namelist()
+            # zipfile does utf-8 decoding on its own; this is just to make
+            # sure we have only unicode objects as brush names.
+            names = [s.decode('utf-8') for s in names]
 
-        readme = None
-        if _BRUSHPACK_README in names:
-            readme = zip.read(_BRUSHPACK_README)
+            readme = None
+            if _BRUSHPACK_README in names:
+                readme = zf.read(_BRUSHPACK_README)
 
-        if _BRUSHPACK_ORDERCONF not in names:
-            raise InvalidBrushpack(C_(
-                "brushpack import failure messages",
-                u"No file named “{order_conf_file}”. "
-                u"This is not a brushpack."
-            ).format(
-                order_conf_file = _BRUSHPACK_ORDERCONF,
-            ))
-        groups = _parse_order_conf(zip.read(_BRUSHPACK_ORDERCONF))
-
-        new_brushes = []
-        for brushes in groups.itervalues():
-            for brush in brushes:
-                if brush not in new_brushes:
-                    new_brushes.append(brush)
-        logger.info(
-            "%d different brushes found in %r of brushpack",
-            len(new_brushes),
-            _BRUSHPACK_ORDERCONF,
-        )
-
-        # Validate file content. The names in order.conf and the
-        # brushes found in the zip must match. This should catch
-        # encoding screwups, everything should be a unicode object.
-        for brush in new_brushes:
-            if brush + '.myb' not in names:
+            if _BRUSHPACK_ORDERCONF not in names:
                 raise InvalidBrushpack(C_(
                     "brushpack import failure messages",
-                    u"Brush “{brush_name}” is "
-                    u"listed in “{order_conf_file}”, "
-                    u"but it does not exist in the zipfile."
+                    u"No file named “{order_conf_file}”. "
+                    u"This is not a brushpack."
                 ).format(
-                    brush_name = brush,
                     order_conf_file = _BRUSHPACK_ORDERCONF,
                 ))
-        for name in names:
-            if name.endswith('.myb'):
-                brush = name[:-4]
-                if brush not in new_brushes:
+            groups = _parse_order_conf(zf.read(_BRUSHPACK_ORDERCONF))
+
+            new_brushes = []
+            for brushes in groups.itervalues():
+                for brush in brushes:
+                    if brush not in new_brushes:
+                        new_brushes.append(brush)
+            logger.info(
+                "%d different brushes found in %r of brushpack",
+                len(new_brushes),
+                _BRUSHPACK_ORDERCONF,
+            )
+
+            # Validate file content. The names in order.conf and the
+            # brushes found in the zip must match. This should catch
+            # encoding screwups, everything should be a unicode object.
+            for brush in new_brushes:
+                if brush + '.myb' not in names:
                     raise InvalidBrushpack(C_(
                         "brushpack import failure messages",
-                        u"Brush “{brush_name}” exists in the zipfile, "
-                        u"but it is not listed in “{order_conf_file}”."
+                        u"Brush “{brush_name}” is "
+                        u"listed in “{order_conf_file}”, "
+                        u"but it does not exist in the zipfile."
                     ).format(
                         brush_name = brush,
                         order_conf_file = _BRUSHPACK_ORDERCONF,
                     ))
-        if readme:
-            answer = dialogs.confirm_brushpack_import(
-                basename(path), window, readme,
-            )
-            if answer == Gtk.ResponseType.REJECT:
-                return set()
-
-        do_overwrite = False
-        do_ask = True
-        renamed_brushes = {}
-        imported_groups = set()
-        for groupname, brushes in groups.iteritems():
-            managed_brushes = self.get_group_brushes(groupname)
-            if managed_brushes:
-                answer = dialogs.confirm_rewrite_group(
-                    window, translate_group_name(groupname),
-                    translate_group_name(DELETED_BRUSH_GROUP))
-                if answer == dialogs.CANCEL:
+            for name in names:
+                if name.endswith('.myb'):
+                    brush = name[:-4]
+                    if brush not in new_brushes:
+                        raise InvalidBrushpack(C_(
+                            "brushpack import failure messages",
+                            u"Brush “{brush_name}” exists in the zipfile, "
+                            u"but it is not listed in “{order_conf_file}”."
+                        ).format(
+                            brush_name = brush,
+                            order_conf_file = _BRUSHPACK_ORDERCONF,
+                        ))
+            if readme:
+                answer = dialogs.confirm_brushpack_import(
+                    basename(path), window, readme,
+                )
+                if answer == Gtk.ResponseType.REJECT:
                     return set()
-                elif answer == dialogs.OVERWRITE_THIS:
-                    self.delete_group(groupname)
-                elif answer == dialogs.DONT_OVERWRITE_THIS:
-                    i = 0
-                    old_groupname = groupname
-                    while groupname in self.groups:
-                        i += 1
-                        groupname = old_groupname + '#%d' % i
+
+            do_overwrite = False
+            do_ask = True
+            renamed_brushes = {}
+            imported_groups = set()
+            for groupname, brushes in groups.iteritems():
                 managed_brushes = self.get_group_brushes(groupname)
-            imported_groups.add(groupname)
-
-            for brushname in brushes:
-                # extract the brush from the zip
-                assert (brushname + '.myb') in zip.namelist()
-                # Support for utf-8 ZIP filenames that don't have
-                # the utf-8 bit set.
-                brushname_utf8 = brushname.encode('utf-8')
-                try:
-                    myb_data = zip.read(brushname + '.myb')
-                except KeyError:
-                    myb_data = zip.read(brushname_utf8 + '.myb')
-                try:
-                    preview_data = zip.read(brushname + '_prev.png')
-                except KeyError:
-                    preview_data = zip.read(brushname_utf8 + '_prev.png')
-                # in case we have imported that brush already in a
-                # previous group, but decided to rename it
-                if brushname in renamed_brushes:
-                    brushname = renamed_brushes[brushname]
-                # possibly ask how to import the brush file
-                # (if we didn't already)
-                b = self.get_brush_by_name(brushname)
-                if brushname in new_brushes:
-                    new_brushes.remove(brushname)
-                    if b:
-                        existing_preview_pixbuf = b.preview
-                        if do_ask:
-                            answer = dialogs.confirm_rewrite_brush(
-                                window, brushname, existing_preview_pixbuf,
-                                preview_data,
-                            )
-                            if answer == dialogs.CANCEL:
-                                break
-                            elif answer == dialogs.OVERWRITE_ALL:
-                                do_overwrite = True
-                                do_ask = False
-                            elif answer == dialogs.OVERWRITE_THIS:
-                                do_overwrite = True
-                                do_ask = True
-                            elif answer == dialogs.DONT_OVERWRITE_THIS:
-                                do_overwrite = False
-                                do_ask = True
-                            elif answer == dialogs.DONT_OVERWRITE_ANYTHING:
-                                do_overwrite = False
-                                do_ask = False
-                        # find a new name (if requested)
-                        brushname_old = brushname
+                if managed_brushes:
+                    answer = dialogs.confirm_rewrite_group(
+                        window, translate_group_name(groupname),
+                        translate_group_name(DELETED_BRUSH_GROUP))
+                    if answer == dialogs.CANCEL:
+                        return set()
+                    elif answer == dialogs.OVERWRITE_THIS:
+                        self.delete_group(groupname)
+                    elif answer == dialogs.DONT_OVERWRITE_THIS:
                         i = 0
-                        while not do_overwrite and b:
+                        old_groupname = groupname
+                        while groupname in self.groups:
                             i += 1
-                            brushname = brushname_old + '#%d' % i
-                            renamed_brushes[brushname_old] = brushname
-                            b = self.get_brush_by_name(brushname)
+                            groupname = old_groupname + '#%d' % i
+                    managed_brushes = self.get_group_brushes(groupname)
+                imported_groups.add(groupname)
 
-                    if not b:
-                        b = ManagedBrush(self, brushname)
+                for brushname in brushes:
+                    # extract the brush from the zip
+                    assert (brushname + '.myb') in zf.namelist()
+                    # Support for utf-8 ZIP filenames that don't have
+                    # the utf-8 bit set.
+                    brushname_utf8 = brushname.encode('utf-8')
+                    try:
+                        myb_data = zf.read(brushname + '.myb')
+                    except KeyError:
+                        myb_data = zf.read(brushname_utf8 + '.myb')
+                    try:
+                        preview_data = zf.read(brushname + '_prev.png')
+                    except KeyError:
+                        preview_data = zf.read(brushname_utf8 + '_prev.png')
+                    # in case we have imported that brush already in a
+                    # previous group, but decided to rename it
+                    if brushname in renamed_brushes:
+                        brushname = renamed_brushes[brushname]
+                    # possibly ask how to import the brush file
+                    # (if we didn't already)
+                    b = self.get_brush_by_name(brushname)
+                    if brushname in new_brushes:
+                        new_brushes.remove(brushname)
+                        if b:
+                            existing_preview_pixbuf = b.preview
+                            if do_ask:
+                                answer = dialogs.confirm_rewrite_brush(
+                                    window, brushname, existing_preview_pixbuf,
+                                    preview_data,
+                                )
+                                if answer == dialogs.CANCEL:
+                                    break
+                                elif answer == dialogs.OVERWRITE_ALL:
+                                    do_overwrite = True
+                                    do_ask = False
+                                elif answer == dialogs.OVERWRITE_THIS:
+                                    do_overwrite = True
+                                    do_ask = True
+                                elif answer == dialogs.DONT_OVERWRITE_THIS:
+                                    do_overwrite = False
+                                    do_ask = True
+                                elif answer == dialogs.DONT_OVERWRITE_ANYTHING:
+                                    do_overwrite = False
+                                    do_ask = False
+                            # find a new name (if requested)
+                            brushname_old = brushname
+                            i = 0
+                            while not do_overwrite and b:
+                                i += 1
+                                brushname = brushname_old + '#%d' % i
+                                renamed_brushes[brushname_old] = brushname
+                                b = self.get_brush_by_name(brushname)
 
-                    # write to disk and reload brush (if overwritten)
-                    prefix = b._get_fileprefix(saving=True)
-                    with open(prefix + '.myb', 'w') as myb_f:
-                        myb_f.write(myb_data)
-                    with open(prefix + '_prev.png', 'wb') as preview_f:
-                        preview_f.write(preview_data)
-                    b.load()
-                # finally, add it to the group
-                if b not in managed_brushes:
-                    managed_brushes.append(b)
-                self.brushes_changed(managed_brushes)
+                        if not b:
+                            b = ManagedBrush(self, brushname)
+
+                        # write to disk and reload brush (if overwritten)
+                        prefix = b._get_fileprefix(saving=True)
+                        with open(prefix + '.myb', 'w') as myb_f:
+                            myb_f.write(myb_data)
+                        with open(prefix + '_prev.png', 'wb') as preview_f:
+                            preview_f.write(preview_data)
+                        b.load()
+                    # finally, add it to the group
+                    if b not in managed_brushes:
+                        managed_brushes.append(b)
+                    self.brushes_changed(managed_brushes)
 
         if DELETED_BRUSH_GROUP in self.groups:
             # remove deleted brushes that are in some group again
@@ -651,16 +651,15 @@ class BrushManager (object):
 
     def export_group(self, group, filename):
         """Exports a group to a brushpack zipfile."""
-        zip = zipfile.ZipFile(filename, mode='w')
         brushes = self.get_group_brushes(group)
         order_conf = 'Group: %s\n' % group.encode('utf-8')
-        for brush in brushes:
-            prefix = brush._get_fileprefix()
-            zip.write(prefix + '.myb', brush.name + '.myb')
-            zip.write(prefix + '_prev.png', brush.name + '_prev.png')
-            order_conf += brush.name.encode('utf-8') + '\n'
-        zip.writestr('order.conf', order_conf)
-        zip.close()
+        with zipfile.ZipFile(filename, mode='w') as zf:
+            for brush in brushes:
+                prefix = brush._get_fileprefix()
+                zf.write(prefix + '.myb', brush.name + '.myb')
+                zf.write(prefix + '_prev.png', brush.name + '_prev.png')
+                order_conf += brush.name.encode('utf-8') + '\n'
+            zf.writestr('order.conf', order_conf)
 
     ## Brush lookup / access
 

--- a/gui/brushmanager.py
+++ b/gui/brushmanager.py
@@ -197,7 +197,8 @@ class BrushManager (object):
         """Load a groups dict from an order.conf file."""
         groups = {}
         if os.path.exists(filename):
-            groups = _parse_order_conf(open(filename).read())
+            with open(filename) as fp:
+                groups = _parse_order_conf(fp.read())
             # replace brush names with ManagedBrush instances
             for group, names in groups.items():
                 brushes = []
@@ -633,12 +634,10 @@ class BrushManager (object):
 
                     # write to disk and reload brush (if overwritten)
                     prefix = b._get_fileprefix(saving=True)
-                    myb_f = open(prefix + '.myb', 'w')
-                    myb_f.write(myb_data)
-                    myb_f.close()
-                    preview_f = open(prefix + '_prev.png', 'wb')
-                    preview_f.write(preview_data)
-                    preview_f.close()
+                    with open(prefix + '.myb', 'w') as myb_f:
+                        myb_f.write(myb_data)
+                    with open(prefix + '_prev.png', 'wb') as preview_f:
+                        preview_f.write(preview_data)
                     b.load()
                 # finally, add it to the group
                 if b not in managed_brushes:
@@ -709,13 +708,12 @@ class BrushManager (object):
     def save_brushorder(self):
         """Save the user's chosen brush order to disk."""
 
-        f = open(os.path.join(self.user_brushpath, 'order.conf'), 'w')
-        f.write('# this file saves brush groups and order\n')
-        for group, brushes in self.groups.iteritems():
-            f.write('Group: %s\n' % group.encode('utf-8'))
-            for b in brushes:
-                f.write(b.name.encode('utf-8') + '\n')
-        f.close()
+        with open(os.path.join(self.user_brushpath, 'order.conf'), 'w') as f:
+            f.write('# this file saves brush groups and order\n')
+            for group, brushes in self.groups.iteritems():
+                f.write('Group: %s\n' % group.encode('utf-8'))
+                for b in brushes:
+                    f.write(b.name.encode('utf-8') + '\n')
 
     ## The selected brush
 
@@ -1135,9 +1133,8 @@ class ManagedBrush(object):
         brushinfo = self.brushinfo.clone()
         settings_filename = prefix + '.myb'
         logger.debug("Saving brush settings to %r", settings_filename)
-        settings_fp = open(settings_filename, 'w')
-        settings_fp.write(brushinfo.save_to_string())
-        settings_fp.close()
+        with open(settings_filename, 'w') as settings_fp:
+            settings_fp.write(brushinfo.save_to_string())
         # Record metadata
         self._remember_mtimes()
 
@@ -1200,7 +1197,8 @@ class ManagedBrush(object):
         """Loads the brush settings/dynamics from disk."""
         prefix = self._get_fileprefix()
         filename = prefix + '.myb'
-        brushinfo_str = open(filename).read()
+        with open(filename) as fp:
+            brushinfo_str = fp.read()
         try:
             self._brushinfo.load_from_string(brushinfo_str)
         except BrushInfo.ParseError as e:

--- a/gui/colors/paletteview.py
+++ b/gui/colors/paletteview.py
@@ -1339,10 +1339,9 @@ def palette_save_via_dialog(palette, title, parent=None, preview=None):
         # FIXME: this can overwrite files without prompting the user, if
         # the name hacking above changed the filename.  Should do the name
         # tweak within the dialog somehow and get that to confirm.
-        fp = open(filename, 'w')
-        palette.save(fp)
-        fp.flush()
-        fp.close()
+        with open(filename, 'w') as fp:
+            palette.save(fp)
+            fp.flush()
         result = True
     dialog.destroy()
     return result

--- a/gui/drawutils.py
+++ b/gui/drawutils.py
@@ -517,9 +517,8 @@ if __name__ == '__main__':
         if not myb_file.lower().endswith(".myb"):
             logger.warning("Ignored %r: not a .myb file", myb_file)
             continue
-        myb_fp = open(myb_file, 'r')
-        myb_json = myb_fp.read()
-        myb_fp.close()
+        with open(myb_file, 'r') as myb_fp:
+            myb_json = myb_fp.read()
         myb_brushinfo = BrushInfo(myb_json)
         myb_pixbuf = render_brush_preview_pixbuf(myb_brushinfo)
         if myb_pixbuf is not None:

--- a/gui/drawwindow.py
+++ b/gui/drawwindow.py
@@ -255,7 +255,8 @@ class DrawWindow (Gtk.Window):
     def _init_menubar(self):
         # Load Menubar, duplicate into self.popupmenu
         menupath = os.path.join(self.app.datapath, 'gui/menu.xml')
-        menubar_xml = open(menupath).read()
+        with open(menupath) as fp:
+            menubar_xml = fp.read()
         self.app.ui_manager.add_ui_from_string(menubar_xml)
         self.popupmenu = self._clone_menu(menubar_xml, 'PopupMenu', self.app.doc.tdw)
         self.menubar = self.app.ui_manager.get_widget('/Menubar')

--- a/lib/brushes_migrate_json.py
+++ b/lib/brushes_migrate_json.py
@@ -19,8 +19,10 @@ def migrate_brushes_to_json(dirpath):
     files = [os.path.join(dirpath, fn)for fn in files if os.path.splitext(fn)[1] == '.myb']
 
     for fpath in files:
-        b = brush.BrushInfo(open(fpath, 'r').read())
-        open(fpath, 'w').write(b.to_json())
+        with open(fpath, 'r') as fp:
+            b = brush.BrushInfo(fp.read())
+        with open(fpath, 'w') as fp:
+            fp.write(b.to_json())
 
 
 if __name__ == '__main__':

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -334,8 +334,8 @@ def get_pixbuf(filename):
     if ext == ".ora":
         thumb_entry = "Thumbnails/thumbnail.png"
         try:
-            orazip = zipfile.ZipFile(filename)
-            pixbuf = lib.pixbuf.load_from_zipfile(orazip, thumb_entry)
+            with zipfile.ZipFile(filename) as orazip:
+                pixbuf = lib.pixbuf.load_from_zipfile(orazip, thumb_entry)
         except:
             logger.exception(
                 "Failed to read %r entry of %r",

--- a/lib/layer/tree.py
+++ b/lib/layer/tree.py
@@ -1771,15 +1771,15 @@ class RootLayerStack (group.LayerStack):
         >>> import shutil
         >>> tmpdir = tempfile.mkdtemp()
         >>> assert os.path.exists(tmpdir)
-        >>> orazip = zipfile.ZipFile("tests/bigimage.ora")
-        >>> image_elem = ET.fromstring(orazip.read("stack.xml"))
-        >>> stack_elem = image_elem.find("stack")
-        >>> root.load_from_openraster(
-        ...    orazip=orazip,
-        ...    elem=stack_elem,
-        ...    cache_dir=tmpdir,
-        ...    feedback_cb=None,
-        ... )
+        >>> with zipfile.ZipFile("tests/bigimage.ora") as orazip:
+        ...     image_elem = ET.fromstring(orazip.read("stack.xml"))
+        ...     stack_elem = image_elem.find("stack")
+        ...     root.load_from_openraster(
+        ...         orazip=orazip,
+        ...         elem=stack_elem,
+        ...         cache_dir=tmpdir,
+        ...         feedback_cb=None,
+        ...     )
         >>> len(list(root.walk())) > 0
         True
         >>> shutil.rmtree(tmpdir)

--- a/lib/palette.py
+++ b/lib/palette.py
@@ -97,9 +97,8 @@ class Palette (object):
         elif filehandle:
             self.load(filehandle, silent=True)
         elif filename:
-            fp = open(filename, "r")
-            self.load(fp, silent=True)
-            fp.close()
+            with open(filename, "r") as fp:
+                self.load(fp, silent=True)
 
     def clear(self, silent=False):
         """Resets the palette to its initial state.
@@ -134,7 +133,8 @@ class Palette (object):
         :param bool silent: If true, don't emit any events.
 
         >>> pal = Palette()
-        >>> pal.load(open("palettes/MyPaint_Default.gpl", "r"))
+        >>> with open("palettes/MyPaint_Default.gpl", "r") as fp:
+        ...     pal.load(fp)
         >>> len(pal) > 1
         True
 

--- a/lib/pixbuf.py
+++ b/lib/pixbuf.py
@@ -127,8 +127,8 @@ def load_from_zipfile(datazip, filename, feedback_cb=None):
     :returns: the loaded pixbuf
 
     >>> import zipfile
-    >>> z = zipfile.ZipFile("tests/smallimage.ora", mode="r")
-    >>> p = load_from_zipfile(z, "Thumbnails/thumbnail.png")
+    >>> with zipfile.ZipFile("tests/smallimage.ora", mode="r") as z:
+    ...     p = load_from_zipfile(z, "Thumbnails/thumbnail.png")
     >>> isinstance(p, GdkPixbuf.Pixbuf)
     True
 

--- a/lib/pixbuf.py
+++ b/lib/pixbuf.py
@@ -99,8 +99,8 @@ def load_from_stream(fp, feedback_cb=None):
     :rtype: GdkPixbuf.Pixbuf
     :returns: the loaded pixbuf
 
-    >>> fp = open("pixmaps/mypaint_logo.png", "rb")
-    >>> p = load_from_stream(fp)
+    >>> with open("pixmaps/mypaint_logo.png", "rb") as fp:
+    ...     p = load_from_stream(fp)
     >>> isinstance(p, GdkPixbuf.Pixbuf)
     True
 

--- a/lib/surface.py
+++ b/lib/surface.py
@@ -286,9 +286,7 @@ def save_as_png(surface, filename, *rect, **kwargs):
         x, y, w, h = (0, 0, 1, 1)
         rect = (x, y, w, h)
 
-    writer_fp = None
     try:
-        writer_fp = open(filename, "wb")
         logger.debug(
             "Writing %r (%dx%d) alpha=%r srgb=%r",
             filename,
@@ -296,25 +294,26 @@ def save_as_png(surface, filename, *rect, **kwargs):
             alpha,
             save_srgb_chunks,
         )
-        pngsave = mypaintlib.ProgressivePNGWriter(
-            writer_fp,
-            w, h,
-            alpha,
-            save_srgb_chunks,
-        )
-        feedback_counter = 0
-        scanline_strips = scanline_strips_iter(
-            surface, rect,
-            alpha=alpha,
-            single_tile_pattern=single_tile_pattern,
-            **kwargs
-        )
-        for scanline_strip in scanline_strips:
-            pngsave.write(scanline_strip)
-            if feedback_cb and feedback_counter % TILES_PER_CALLBACK == 0:
-                feedback_cb()
-            feedback_counter += 1
-        pngsave.close()
+        with open(filename, "wb") as writer_fp:
+            pngsave = mypaintlib.ProgressivePNGWriter(
+                writer_fp,
+                w, h,
+                alpha,
+                save_srgb_chunks,
+            )
+            feedback_counter = 0
+            scanline_strips = scanline_strips_iter(
+                surface, rect,
+                alpha=alpha,
+                single_tile_pattern=single_tile_pattern,
+                **kwargs
+            )
+            for scanline_strip in scanline_strips:
+                pngsave.write(scanline_strip)
+                if feedback_cb and feedback_counter % TILES_PER_CALLBACK == 0:
+                    feedback_cb()
+                feedback_counter += 1
+            pngsave.close()
         logger.debug("Finished writing %r", filename)
     except (IOError, OSError, RuntimeError) as err:
         logger.exception(
@@ -335,6 +334,3 @@ def save_as_png(surface, filename, *rect, **kwargs):
         # Other possible exceptions include TypeError, ValueError, but
         # those indicate incorrect coding usually; just raise them
         # normally.
-    finally:
-        if writer_fp:
-            writer_fp.close()

--- a/svg/symbolic-icons-extract.py
+++ b/svg/symbolic-icons-extract.py
@@ -130,9 +130,8 @@ def main():
         logger.error("No dir named %r", basedir)
         sys.exit(1)
     logger.info("Reading %r", CONTACT_SHEET)
-    svg_fp = gzip.open(CONTACT_SHEET, mode='rb')
-    svg = ET.parse(svg_fp)
-    svg_fp.close()
+    with gzip.open(CONTACT_SHEET, mode='rb') as svg_fp:
+        svg = ET.parse(svg_fp)
     group_ids = sys.argv[1:]
     if group_ids:
         logger.info("Attempting to extract %d icon(s)", len(group_ids))

--- a/tests/test_memory_leak.py
+++ b/tests/test_memory_leak.py
@@ -24,7 +24,8 @@ LEAK_EXIT_CODE = 33
 
 def mem():
     gc.collect()
-    return int(open('/proc/self/statm').read().split()[0])
+    with open('/proc/self/statm') as statm:
+        return int(statm.read().split()[0])
 
 
 def check_garbage(msg='uncollectable garbage left over from previous tests'):

--- a/tests/test_mypaintlib.py
+++ b/tests/test_mypaintlib.py
@@ -108,7 +108,8 @@ def directPaint():
 def brushPaint():
 
     s = tiledsurface.Surface()
-    bi = brush.BrushInfo(open('brushes/charcoal.myb').read())
+    with open('brushes/charcoal.myb') as fp:
+        bi = brush.BrushInfo(fp.read())
     b = brush.Brush(bi)
 
     events = np.loadtxt('painting30sec.dat')
@@ -132,7 +133,8 @@ def brushPaint():
 
 
 def files_equal(a, b):
-    return open(a, 'rb').read() == open(b, 'rb').read()
+    with open(a, 'rb') as af, open(b, 'rb') as bf:
+        return af.read() == bf.read()
 
 
 def pngs_equal(a, b):
@@ -199,10 +201,13 @@ def pngs_equal(a, b):
 
 
 def docPaint():
-    b1 = brush.BrushInfo(open('brushes/s008.myb').read())
-    b2 = brush.BrushInfo(open('brushes/redbrush.myb').read())
+    with open('brushes/s008.myb') as fp:
+        b1 = brush.BrushInfo(fp.read())
+    with open('brushes/redbrush.myb') as fp:
+        b2 = brush.BrushInfo(fp.read())
     b2.set_color_hsv((0.3, 0.4, 0.35))
-    b3 = brush.BrushInfo(open('brushes/watercolor.myb').read())
+    with open('brushes/watercolor.myb') as fp:
+        b3 = brush.BrushInfo(fp.read())
     b3.set_color_hsv((0.9, 0.2, 0.2))
 
     b = brush.BrushInfo()

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -205,7 +205,8 @@ def save_png_layer():
 def brushengine_paint_hires():
     from lib import tiledsurface, brush
     s = tiledsurface.Surface()
-    bi = brush.BrushInfo(open('brushes/watercolor.myb').read())
+    with open('brushes/watercolor.myb') as fp:
+        bi = brush.BrushInfo(fp.read())
     b = brush.Brush(bi)
 
     events = np.loadtxt('painting30sec.dat')
@@ -301,7 +302,8 @@ def memory_zoomed_out_5x(gui):
     gui.zoom_out(5)
     gui.wait_for_idle()
     gui.scroll()
-    print('result =', open('/proc/self/statm').read().split()[0])
+    with open('/proc/self/statm') as statm:
+        print('result =', statm.read().split()[0])
     if False:
         yield None  # just to make this function iterator
 
@@ -313,7 +315,8 @@ def memory_after_startup(gui):
     gui.wait_for_idle()
     sleep(1)
     gui.wait_for_idle()
-    print('result =', open('/proc/self/statm').read().split()[0])
+    with open('/proc/self/statm') as statm:
+        print('result =', statm.read().split()[0])
     if False:
         yield None  # just to make this function iterator
 


### PR DESCRIPTION
Using a context manager ensures that the file will be closed regardless of any exceptions that might occur. The only file that doesn't work this way is the logger output.