### PR TITLE
Pan shortcuts: allow user to customize keys.

### DIFF
--- a/gui/accelmap.py
+++ b/gui/accelmap.py
@@ -397,8 +397,10 @@ class AccelMapEditor (Gtk.Grid):
         # So we get (<Shift>j, Shift+J) but just (plus, +). As I
         # understand it.
 
-        if not Gtk.accelerator_valid(keyval, mods):
-            return True
+        # This is rejecting some legit key combinations such as the
+        # arrowkeys, so I had to remove it...
+        #if not Gtk.accelerator_valid(keyval, mods):
+        #    return True
 
         clash_accel_path = None
         clash_action_label = None

--- a/gui/document.py
+++ b/gui/document.py
@@ -492,11 +492,6 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
         k('<control>minus', 'ZoomOut')  # Krita
         k('bar', 'SymmetryActive')
 
-        k('Left', lambda action: self.pan(self.PAN_LEFT))
-        k('Right', lambda action: self.pan(self.PAN_RIGHT))
-        k('Down', lambda action: self.pan(self.PAN_DOWN))
-        k('Up', lambda action: self.pan(self.PAN_UP))
-
         k('<control>Left', 'RotateLeft')
         k('<control>Right', 'RotateRight')
 
@@ -1676,6 +1671,17 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
         if action.get_name() == 'ZoomOut':
             direction = self.ZOOM_OUTWARDS
         self.zoom(direction)
+
+    def pan_cb(self, action):
+        """Callback for Pan{Left,Right,Up,Down} GtkActions"""
+        direction = self.PAN_LEFT
+        if action.get_name() == 'PanRight':
+            direction = self.PAN_RIGHT
+        elif action.get_name() == 'PanUp':
+            direction = self.PAN_UP
+        elif action.get_name() == 'PanDown':
+            direction = self.PAN_DOWN
+        self.pan(direction)
 
     def rotate_cb(self, action):
         """Callback for Rotate{Left,Right} GtkActions"""

--- a/gui/document.py
+++ b/gui/document.py
@@ -492,6 +492,11 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
         k('<control>minus', 'ZoomOut')  # Krita
         k('bar', 'SymmetryActive')
 
+        k('Left', lambda action: self.pan(self.PAN_LEFT))
+        k('Right', lambda action: self.pan(self.PAN_RIGHT))
+        k('Down', lambda action: self.pan(self.PAN_DOWN))
+        k('Up', lambda action: self.pan(self.PAN_UP))
+
         k('<control>Left', 'RotateLeft')
         k('<control>Right', 'RotateRight')
 

--- a/gui/resources.xml
+++ b/gui/resources.xml
@@ -634,6 +634,38 @@ Vocabulary
         <accelerator key="comma"/>
       </child>
       <child>
+        <object class="GtkAction" id="PanLeft">
+          <property name="label" translatable="yes" context="Menu→View→Adjust View (labels), Accel Editor (labels)">Pan Left</property>
+          <property name="tooltip" translatable="yes" context="Accel Editor (descriptions)">Move your view of the canvas to the left.</property>
+          <signal name="activate" handler="pan_cb"/>
+        </object>
+        <accelerator key="Left"/>
+      </child>
+      <child>
+        <object class="GtkAction" id="PanRight">
+          <property name="label" translatable="yes" context="Menu→View→Adjust View (labels), Accel Editor (labels)">Pan Right</property>
+          <property name="tooltip" translatable="yes" context="Accel Editor (descriptions)">Move your view of the canvas to the right.</property>
+          <signal name="activate" handler="pan_cb"/>
+        </object>
+        <accelerator key="Right"/>
+      </child>
+      <child>
+        <object class="GtkAction" id="PanUp">
+          <property name="label" translatable="yes" context="Menu→View→Adjust View (labels), Accel Editor (labels)">Pan Up</property>
+          <property name="tooltip" translatable="yes" context="Accel Editor (descriptions)">Move your view of the canvas upwards.</property>
+          <signal name="activate" handler="pan_cb"/>
+        </object>
+        <accelerator key="Up"/>
+      </child>
+      <child>
+        <object class="GtkAction" id="PanDown">
+          <property name="label" translatable="yes" context="Menu→View→Adjust View (labels), Accel Editor (labels)">Pan Down</property>
+          <property name="tooltip" translatable="yes" context="Accel Editor (descriptions)">Move your view of the canvas downwards.</property>
+          <signal name="activate" handler="pan_cb"/>
+        </object>
+        <accelerator key="Down"/>
+      </child>
+      <child>
         <object class="GtkAction" id="RotateLeft">
           <property name="icon-name">mypaint-view-rotate-clockwise-symbolic</property>
           <!--


### PR DESCRIPTION
Pan Left, Pan Right, Pan Down and Pan Up used to be hardcoded into the arrow keys. I find this really awkward, as I need to pan often, my shortcut hand is sitting in the opposite side of the keyboard, and the spacebar option is a three step process my brain refuses to get used to. (Hit space, pan, hit space again.)

This commit allows the user to customize the four directional pan actions.

Objections?
Please review this change in particular:
https://github.com/ydahhrk/mypaint/commit/a165e6ab1275da0d4debf507ec2d235803ef8514#diff-43086ad29962d3495933ef1c3bc3ad5bL400