### PR TITLE
py3k: Remove __future__ import from main script.

### DIFF
--- a/mypaint.py
+++ b/mypaint.py
@@ -18,7 +18,6 @@ It then passes control to gui.main.main() for command line launching.
 """
 
 ## Imports (standard Python only at this point)
-from __future__ import print_function
 
 import sys
 import os


### PR DESCRIPTION
There is no printing here, and the automatic version generation inserts
code at the beginning of the file, thus breaking with the __future__
import.

Fixes #695.