### PR TITLE
quickchoice: Show brush description in tooltip

### DIFF
--- a/gui/brushselectionwindow.py
+++ b/gui/brushselectionwindow.py
@@ -38,11 +38,13 @@ logger = logging.getLogger(__name__)
 
 ## Helper functions
 
-def _managedbrush_idfunc(managedbrush):
+def managedbrush_idfunc(managedbrush):
+    """Returns the id of a ManagedBrush."""
     return managedbrush.name
 
 
-def _managedbrush_namefunc(managedbrush):
+def managedbrush_namefunc(managedbrush):
+    """Returns tooltip of a ManagedBrush."""
     template = "{name}"
     if managedbrush.description:
         template = "{name}\n{description}"
@@ -51,8 +53,8 @@ def _managedbrush_namefunc(managedbrush):
         description = managedbrush.description,
     )
 
-
-def _managedbrush_pixbuffunc(managedbrush):
+def managedbrush_pixbuffunc(managedbrush):
+    """Returns pixbuf preview of a ManagedBrush."""
     return managedbrush.preview
 
 
@@ -75,9 +77,9 @@ class BrushList (pixbuflist.PixbufList):
         s = self.ICON_SIZE
         super(BrushList, self).__init__(
             self.brushes, s, s,
-            namefunc=_managedbrush_namefunc,
-            pixbuffunc=_managedbrush_pixbuffunc,
-            idfunc = _managedbrush_idfunc,
+            namefunc=managedbrush_namefunc,
+            pixbuffunc=managedbrush_pixbuffunc,
+            idfunc=managedbrush_idfunc,
         )
         self.set_selected(self.bm.selected_brush)
         self.bm.groups_changed += self._groups_changed_cb

--- a/gui/quickchoice.py
+++ b/gui/quickchoice.py
@@ -17,12 +17,12 @@ from gi.repository import Gtk
 
 from pixbuflist import PixbufList
 import brushmanager
+import brushselectionwindow
 import widgets
 import spinbox
 import windowing
 from lib.observable import event
 import gui.colortools
-
 
 ## Module consts
 
@@ -84,9 +84,12 @@ class QuickBrushChooser (Gtk.VBox):
 
         brushes = self.bm.get_group_brushes(active_group_name)
 
-        self.brushlist = PixbufList(brushes, self.ICON_SIZE, self.ICON_SIZE,
-                                    namefunc=lambda x: x.name,
-                                    pixbuffunc=lambda x: x.preview)
+        self.brushlist = PixbufList(
+            brushes, self.ICON_SIZE, self.ICON_SIZE,
+            namefunc=brushselectionwindow.managedbrush_namefunc,
+            pixbuffunc=brushselectionwindow.managedbrush_pixbuffunc,
+            idfunc=brushselectionwindow.managedbrush_idfunc
+        )
         self.brushlist.dragging_allowed = False
         self.bm.groups_changed += self._groups_changed_cb
         self.bm.brushes_changed += self._brushes_changed_cb


### PR DESCRIPTION
The brush selection window shows the tooltip, but it was not shown in
the quickchoice selector (default keyed to B) before. This commit
improves brush selection experience.

The existing brush id/icon/tooltip functions in brushselectionwindow
were made public.

Closes mypaint/mypaint#702.