### PR TITLE
[RFC] Alternative symmetry modes

### DIFF
--- a/gui/document.py
+++ b/gui/document.py
@@ -1723,16 +1723,19 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
         want_active = bool(action.get_active())
         if want_active and not already_active:
             alloc = self.tdw.get_allocation()
-            axis_pos = self.model.layer_stack.symmetry_axis
-            if axis_pos is None:
+            axis_x_pos = self.model.layer_stack.symmetry_x
+            axis_y_pos = self.model.layer_stack.symmetry_y
+            if axis_x_pos is None or axis_y_pos is None:
                 center_disp = alloc.width / 2.0, alloc.height / 2.0
                 center_model = self.tdw.display_to_model(*center_disp)
-                axis_pos = center_model[0]
-                self.model.layer_stack.symmetry_axis = axis_pos
+                axis_x_pos = center_model[0]
+                axis_y_pos = center_model[1]
+                self.model.layer_stack.symmetry_x = axis_x_pos
+                self.model.layer_stack.symmetry_y = axis_y_pos
         if want_active != already_active:
             self.model.layer_stack.symmetry_active = want_active
 
-    def _symmetry_state_changed_cb(self, layerstack, active, x):
+    def _symmetry_state_changed_cb(self, layerstack, active, x, y, sym_type, rot_sym_lines):
         """Update the SymmetryActive toggle on model state changes"""
         symm_toggle = self.action_group.get_action("SymmetryActive")
         symm_toggle_active = bool(symm_toggle.get_active())

--- a/gui/symmetry.py
+++ b/gui/symmetry.py
@@ -420,7 +420,7 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
         )
         self._axis_rot_symmetry_lines = Gtk.Adjustment(
             rootstack.rot_symmetry_lines,
-            upper=9,
+            upper=50,
             lower=2,
             step_incr=1,
             page_incr=3,

--- a/gui/symmetry.py
+++ b/gui/symmetry.py
@@ -23,6 +23,8 @@ import gui.tileddrawwidget
 import lib.alg
 from lib.color import RGBColor
 import lib.helpers
+import lib.mypaintlib
+import lib.tiledsurface
 import gui.drawutils
 from lib.gettext import C_
 
@@ -42,8 +44,9 @@ class _EditZone:
 
     UNKNOWN = 0
     CREATE_AXIS = 1
-    MOVE_AXIS = 2
-    DELETE_AXIS = 3
+    MOVE_X_AXIS = 2
+    MOVE_Y_AXIS = 3
+    DELETE_AXIS = 4
 
 
 class SymmetryEditMode (gui.mode.ScrollableModeMixin, gui.mode.DragMode):
@@ -113,8 +116,10 @@ class SymmetryEditMode (gui.mode.ScrollableModeMixin, gui.mode.DragMode):
         self.app = app
         statusbar_cid = app.statusbar.get_context_id(self._STATUSBAR_CONTEXT)
         self._statusbar_context_id = statusbar_cid
-        self._drag_start_axis = None
+        self._drag_start_x = None
+        self._drag_start_y = None
         self._drag_start_model_x = None
+        self._drag_start_model_y = None
         self.zone = _EditZone.UNKNOWN
         self._last_msg_zone = None
         self._click_info = None
@@ -150,7 +155,8 @@ class SymmetryEditMode (gui.mode.ScrollableModeMixin, gui.mode.DragMode):
         statusbar.remove_all(statusbar_cid)
         msgs = {
             _EditZone.CREATE_AXIS: self._STATUSBAR_CREATE_AXIS_MSG,
-            _EditZone.MOVE_AXIS: self._STATUSBAR_MOVE_AXIS_MSG,
+            _EditZone.MOVE_X_AXIS: self._STATUSBAR_MOVE_AXIS_MSG,
+            _EditZone.MOVE_Y_AXIS: self._STATUSBAR_MOVE_AXIS_MSG,
             _EditZone.DELETE_AXIS: self._STATUSBAR_DELETE_AXIS_MSG,
         }
         msg = msgs.get(self.zone, None)
@@ -187,7 +193,8 @@ class SymmetryEditMode (gui.mode.ScrollableModeMixin, gui.mode.DragMode):
                         layer_stack.symmetry_active = False
                     elif zone0 == _EditZone.CREATE_AXIS:
                         x, y = tdw.display_to_model(event.x, event.y)
-                        layer_stack.symmetry_axis = x
+                        layer_stack.symmetry_x = x
+                        layer_stack.symmetry_y = y
                         layer_stack.symmetry_active = True
                 self._click_info = None
                 self._update_zone_and_cursor(tdw, event.x, event.y)
@@ -212,7 +219,8 @@ class SymmetryEditMode (gui.mode.ScrollableModeMixin, gui.mode.DragMode):
         xm, ym = tdw.display_to_model(x, y)
         model = tdw.doc
         layer_stack = model.layer_stack
-        axis = layer_stack.symmetry_axis
+        axis_x = layer_stack.symmetry_x
+        axis_y = layer_stack.symmetry_y
         if not layer_stack.symmetry_active:
             self.active_cursor = self.cursor_add
             self.inactive_cursor = self.cursor_add
@@ -232,8 +240,8 @@ class SymmetryEditMode (gui.mode.ScrollableModeMixin, gui.mode.DragMode):
         if new_zone is None:
             move_cursor_name, perp_dist = tdw.get_move_cursor_name_for_edge(
                 (x, y),
-                (axis, 0),
-                (axis, 1000),
+                (axis_x, 0),
+                (axis_x, 1000),
                 tolerance=self._GRAB_SENSITIVITY,
                 finite=False,
             )
@@ -247,7 +255,32 @@ class SymmetryEditMode (gui.mode.ScrollableModeMixin, gui.mode.DragMode):
                     self._move_cursors[move_cursor_name] = move_cursor
                 self.active_cursor = move_cursor
                 self.inactive_cursor = move_cursor
-                new_zone = _EditZone.MOVE_AXIS
+                new_zone = _EditZone.MOVE_X_AXIS
+            dfrac = lib.helpers.clamp(
+                perp_dist / (10.0 * self._GRAB_SENSITIVITY),
+                0.0, 1.0,
+            )
+            new_alphafrac = 1.0 - dfrac
+
+        if new_zone is None:
+            move_cursor_name, perp_dist = tdw.get_move_cursor_name_for_edge(
+                (x, y),
+                (0, axis_y),
+                (1000, axis_y),
+                tolerance=self._GRAB_SENSITIVITY,
+                finite=False,
+            )
+            if move_cursor_name:
+                move_cursor = self._move_cursors.get(move_cursor_name)
+                if not move_cursor:
+                    move_cursor = self.doc.app.cursors.get_action_cursor(
+                        self.ACTION_NAME,
+                        move_cursor_name,
+                    )
+                    self._move_cursors[move_cursor_name] = move_cursor
+                self.active_cursor = move_cursor
+                self.inactive_cursor = move_cursor
+                new_zone = _EditZone.MOVE_Y_AXIS
             dfrac = lib.helpers.clamp(
                 perp_dist / (10.0 * self._GRAB_SENSITIVITY),
                 0.0, 1.0,
@@ -277,35 +310,54 @@ class SymmetryEditMode (gui.mode.ScrollableModeMixin, gui.mode.DragMode):
         model = tdw.doc
         layer_stack = model.layer_stack
         self._update_zone_and_cursor(tdw, event.x, event.y)
-        if self.zone == _EditZone.MOVE_AXIS:
+        if self.zone == _EditZone.MOVE_X_AXIS:
             x0, y0 = self.start_x, self.start_y
-            self._drag_start_axis = int(round(layer_stack.symmetry_axis))
+            self._drag_start_x = int(round(layer_stack.symmetry_x))
             x0_m, y0_m = tdw.display_to_model(x0, y0)
             self._drag_start_model_x = x0_m
+        elif self.zone == _EditZone.MOVE_Y_AXIS:
+            x0, y0 = self.start_x, self.start_y
+            self._drag_start_y = int(round(layer_stack.symmetry_y))
+            x0_m, y0_m = tdw.display_to_model(x0, y0)
+            self._drag_start_model_y = y0_m
         return super(SymmetryEditMode, self).drag_start_cb(tdw, event)
 
     def drag_update_cb(self, tdw, event, dx, dy):
-        if self.zone == _EditZone.MOVE_AXIS:
+        if self.zone == _EditZone.MOVE_X_AXIS:
             x_m, y_m = tdw.display_to_model(event.x, event.y)
-            axis = self._drag_start_axis + x_m - self._drag_start_model_x
-            axis = int(round(axis))
-            if axis != self._drag_start_axis:
+            x = self._drag_start_x + x_m - self._drag_start_model_x
+            x = int(round(x))
+            if x != self._drag_start_x:
                 model = tdw.doc
                 layer_stack = model.layer_stack
-                layer_stack.symmetry_axis = axis
+                layer_stack.symmetry_x = x
+        elif self.zone == _EditZone.MOVE_Y_AXIS:
+            x_m, y_m = tdw.display_to_model(event.x, event.y)
+            y = self._drag_start_y + y_m - self._drag_start_model_y
+            y = int(round(y))
+            if y != self._drag_start_y:
+                model = tdw.doc
+                layer_stack = model.layer_stack
+                layer_stack.symmetry_y = y
         return super(SymmetryEditMode, self).drag_update_cb(tdw, event, dx, dy)
 
     def drag_stop_cb(self, tdw):
-        if self.zone == _EditZone.MOVE_AXIS:
+        if self.zone == _EditZone.MOVE_X_AXIS:
+            tdw.queue_draw()
+        if self.zone == _EditZone.MOVE_Y_AXIS:
             tdw.queue_draw()
         return super(SymmetryEditMode, self).drag_stop_cb(tdw)
 
 
 class SymmetryEditOptionsWidget (Gtk.Alignment):
 
-    _POSITION_LABEL_TEXT = C_(
+    _POSITION_LABEL_X_TEXT = C_(
         "symmetry axis options panel: labels",
-        u"Position:",
+        u"X Position:",
+    )
+    _POSITION_LABEL_Y_TEXT = C_(
+        "symmetry axis options panel: labels",
+        u"Y Position:",
     )
     _POSITION_BUTTON_TEXT_INACTIVE = C_(
         "symmetry axis options panel: position button: no axis pos.",
@@ -319,6 +371,14 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
         "symmetry axis options panel: labels",
         u"Alpha:",
     )
+    _SYMMETRY_TYPE_TEXT = C_(
+        "symmetry axis options panel: labels",
+        u"Symmetry Type:",
+    )
+    _SYMMETRY_ROT_LINES_TEXT = C_(
+        "symmetry axis options panel: labels",
+        u"Number of rotational lines:",
+    )
 
     def __init__(self):
         super(SymmetryEditOptionsWidget, self).__init__(
@@ -327,25 +387,53 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
             xscale=1.0,
             yscale=1.0,
         )
-        self._axis_pos_dialog = None
-        self._axis_pos_button = None
+        self._axis_pos_x_dialog = None
+        self._axis_pos_x_button = None
+        self._axis_pos_y_dialog = None
+        self._axis_pos_y_button = None
+        self._symmetry_type_combo = None
+        self._axis_rot_sym_lines_entry = None
         from application import get_app
         self.app = get_app()
         rootstack = self.app.doc.model.layer_stack
-        self._axis_pos_adj = Gtk.Adjustment(
-            rootstack.symmetry_axis,
+        self._axis_pos_adj_x = Gtk.Adjustment(
+            rootstack.symmetry_x,
             upper=32000,
             lower=-32000,
             step_incr=1,
             page_incr=100,
         )
-        self._axis_pos_adj.connect(
+        self._axis_pos_adj_x.connect(
             'value-changed',
-            self._axis_pos_adj_changed,
+            self._axis_pos_adj_x_changed,
         )
+        self._axis_pos_adj_y = Gtk.Adjustment(
+            rootstack.symmetry_y,
+            upper=32000,
+            lower=-32000,
+            step_incr=1,
+            page_incr=100,
+        )
+        self._axis_pos_adj_y.connect(
+            'value-changed',
+            self._axis_pos_adj_y_changed,
+        )
+        self._axis_rot_symmetry_lines = Gtk.Adjustment(
+            rootstack.rot_symmetry_lines,
+            upper=9,
+            lower=2,
+            step_incr=1,
+            page_incr=3,
+        )
+        self._axis_rot_symmetry_lines.connect(
+            'value-changed',
+            self._axis_rot_symmetry_lines_changed,
+        )
+
         self._init_ui()
         rootstack.symmetry_state_changed += self._symmetry_state_changed_cb
-        self._update_axis_pos_button_label(rootstack.symmetry_axis)
+        self._update_axis_pos_x_button_label(rootstack.symmetry_x)
+        self._update_axis_pos_y_button_label(rootstack.symmetry_y)
 
     def _init_ui(self):
         app = self.app
@@ -355,7 +443,7 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
         dialog = gui.windowing.Dialog(
             app, C_(
                 "symmetry axis options panel: axis position dialog: window title",
-                u"Axis Position",
+                u"X axis Position",
             ),
             app.drawWindow,
             buttons=buttons,
@@ -365,12 +453,12 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
         grid.set_border_width(gui.widgets.SPACING_LOOSE)
         grid.set_column_spacing(gui.widgets.SPACING)
         grid.set_row_spacing(gui.widgets.SPACING)
-        label = Gtk.Label(self._POSITION_LABEL_TEXT)
+        label = Gtk.Label(self._POSITION_LABEL_X_TEXT)
         label.set_hexpand(False)
         label.set_vexpand(False)
         grid.attach(label, 0, 0, 1, 1)
         entry = Gtk.SpinButton(
-            adjustment=self._axis_pos_adj,
+            adjustment=self._axis_pos_adj_x,
             climb_rate=0.25,
             digits=0
         )
@@ -379,7 +467,38 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
         grid.attach(entry, 1, 0, 1, 1)
         dialog_content_box = dialog.get_content_area()
         dialog_content_box.pack_start(grid, True, True, 0)
-        self._axis_pos_dialog = dialog
+        self._axis_pos_x_dialog = dialog
+
+        # Dialog for showing and editing the axis value directly
+        buttons = (Gtk.STOCK_OK, Gtk.ResponseType.ACCEPT)
+        dialog = gui.windowing.Dialog(
+            app, C_(
+                "symmetry axis options panel: axis position dialog: window title",
+                u"Y axis Position",
+            ),
+            app.drawWindow,
+            buttons=buttons,
+        )
+        dialog.connect('response', self._axis_pos_dialog_response_cb)
+        grid = Gtk.Grid()
+        grid.set_border_width(gui.widgets.SPACING_LOOSE)
+        grid.set_column_spacing(gui.widgets.SPACING)
+        grid.set_row_spacing(gui.widgets.SPACING)
+        label = Gtk.Label(self._POSITION_LABEL_Y_TEXT)
+        label.set_hexpand(False)
+        label.set_vexpand(False)
+        grid.attach(label, 0, 0, 1, 1)
+        entry = Gtk.SpinButton(
+            adjustment=self._axis_pos_adj_y,
+            climb_rate=0.25,
+            digits=0
+        )
+        entry.set_hexpand(True)
+        entry.set_vexpand(False)
+        grid.attach(entry, 1, 0, 1, 1)
+        dialog_content_box = dialog.get_content_area()
+        dialog_content_box.pack_start(grid, True, True, 0)
+        self._axis_pos_y_dialog = dialog
 
         # Layout grid
         row = 0
@@ -409,17 +528,67 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
         grid.attach(scale, 1, row, 1, 1)
 
         row += 1
-        label = Gtk.Label(self._POSITION_LABEL_TEXT)
+        store = Gtk.ListStore(int, str)
+        sym_types = lib.tiledsurface.SYMMETRY_TYPES
+        active_idx = 0
+        rootstack = self.app.doc.model.layer_stack
+        starts_with_rotate = (rootstack.symmetry_type == lib.mypaintlib.SymmetryRotational)
+        for i, sym_type in enumerate(sym_types):
+            label = lib.tiledsurface.SYMMETRY_STRINGS.get(sym_type)
+            store.append([sym_type, label])
+            if sym_type == rootstack.symmetry_type:
+                active_idx = i
+        self._symmetry_type_combo = Gtk.ComboBox()
+        self._symmetry_type_combo.set_model(store)
+        self._symmetry_type_combo.set_active(active_idx)
+        self._symmetry_type_combo.set_hexpand(True)
+        cell = Gtk.CellRendererText()
+        self._symmetry_type_combo.pack_start(cell, True)
+        self._symmetry_type_combo.add_attribute(cell, "text", 1)
+        self._symmetry_type_combo.connect('changed',
+                   self._symmetry_type_combo_changed_cb)
+        label = Gtk.Label(self._SYMMETRY_TYPE_TEXT)
+        label.set_hexpand(False)
+        label.set_halign(Gtk.Align.START)
+        grid.attach(label, 0, row, 1, 1)
+        grid.attach(self._symmetry_type_combo, 1, row, 1, 1)
+
+        row += 1
+        label = Gtk.Label(self._SYMMETRY_ROT_LINES_TEXT)
+        label.set_hexpand(False)
+        label.set_halign(Gtk.Align.START)
+        self._axis_rot_sym_lines_entry = Gtk.SpinButton(
+            adjustment=self._axis_rot_symmetry_lines,
+            climb_rate=0.25
+        )
+        grid.attach(label, 0, row, 1, 1)
+        grid.attach(self._axis_rot_sym_lines_entry, 1, row, 1, 1)
+
+        row += 1
+        label = Gtk.Label(self._POSITION_LABEL_X_TEXT)
         label.set_hexpand(False)
         label.set_halign(Gtk.Align.START)
         button = Gtk.Button(self._POSITION_BUTTON_TEXT_INACTIVE)
         button.set_vexpand(False)
-        button.connect("clicked", self._axis_pos_button_clicked_cb)
+        button.connect("clicked", self._axis_pos_x_button_clicked_cb)
         button.set_hexpand(True)
         button.set_vexpand(False)
         grid.attach(label, 0, row, 1, 1)
         grid.attach(button, 1, row, 1, 1)
-        self._axis_pos_button = button
+        self._axis_pos_x_button = button
+
+        row += 1
+        label = Gtk.Label(self._POSITION_LABEL_Y_TEXT)
+        label.set_hexpand(False)
+        label.set_halign(Gtk.Align.START)
+        button = Gtk.Button(self._POSITION_BUTTON_TEXT_INACTIVE)
+        button.set_vexpand(False)
+        button.connect("clicked", self._axis_pos_y_button_clicked_cb)
+        button.set_hexpand(True)
+        button.set_vexpand(False)
+        grid.attach(label, 0, row, 1, 1)
+        grid.attach(button, 1, row, 1, 1)
+        self._axis_pos_y_button = button
 
         row += 1
         button = Gtk.CheckButton()
@@ -435,36 +604,87 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
         self._axis_active_button = button
 
 
-    def _symmetry_state_changed_cb(self, rootstack, active, x):
-        self._update_axis_pos_button_label(x)
-        dialog = self._axis_pos_dialog
+    def _symmetry_state_changed_cb(self, rootstack, active, x, y, symmetry_type, rot_symmetry_lines):
+        self._update_axis_pos_x_button_label(x)
+        self._update_axis_pos_y_button_label(y)
+        dialog = self._axis_pos_x_dialog
         dialog_content_box = dialog.get_content_area()
+
         if x is None:
             dialog_content_box.set_sensitive(False)
         else:
             dialog_content_box.set_sensitive(True)
-            adj = self._axis_pos_adj
+            adj = self._axis_pos_adj_x
             adj_pos = int(adj.get_value())
             model_pos = int(x)
             if adj_pos != model_pos:
                 adj.set_value(model_pos)
 
-    def _update_axis_pos_button_label(self, x):
+        dialog = self._axis_pos_y_dialog
+        dialog_content_box = dialog.get_content_area()
+        if y is None:
+            dialog_content_box.set_sensitive(False)
+        else:
+            dialog_content_box.set_sensitive(True)
+            adj = self._axis_pos_adj_y
+            adj_pos = int(adj.get_value())
+            model_pos = int(y)
+            if adj_pos != model_pos:
+                adj.set_value(model_pos)
+
+        if symmetry_type in {lib.mypaintlib.SymmetryRotational, None}:
+            self._axis_rot_sym_lines_entry.set_sensitive(True)
+        else:
+            self._axis_rot_sym_lines_entry.set_sensitive(False)
+
+    def _update_axis_pos_x_button_label(self, x):
         if x is None:
             text = self._POSITION_BUTTON_TEXT_INACTIVE
         else:
             text = self._POSITION_BUTTON_TEXT_TEMPLATE % (x,)
-        self._axis_pos_button.set_label(text)
+        self._axis_pos_x_button.set_label(text)
 
-    def _axis_pos_adj_changed(self, adj):
+    def _update_axis_pos_y_button_label(self, y):
+        if y is None:
+            text = self._POSITION_BUTTON_TEXT_INACTIVE
+        else:
+            text = self._POSITION_BUTTON_TEXT_TEMPLATE % (y,)
+        self._axis_pos_y_button.set_label(text)
+
+    def _axis_pos_adj_x_changed(self, adj):
         rootstack = self.app.doc.model.layer_stack
-        model_pos = int(rootstack.symmetry_axis)
+        model_pos = int(rootstack.symmetry_x)
         adj_pos = int(adj.get_value())
         if adj_pos != model_pos:
-            rootstack.symmetry_axis = adj_pos
+            rootstack.symmetry_x = adj_pos
 
-    def _axis_pos_button_clicked_cb(self, button):
-        self._axis_pos_dialog.show_all()
+    def _axis_rot_symmetry_lines_changed(self, adj):
+        rootstack = self.app.doc.model.layer_stack
+        sym_lines = int(rootstack.rot_symmetry_lines)
+        adj_pos = int(adj.get_value())
+        rootstack.rot_symmetry_lines = adj_pos
+
+    def _axis_pos_adj_y_changed(self, adj):
+        rootstack = self.app.doc.model.layer_stack
+        model_pos = int(rootstack.symmetry_y)
+        adj_pos = int(adj.get_value())
+        if adj_pos != model_pos:
+            rootstack.symmetry_y = adj_pos
+
+    def _axis_pos_x_button_clicked_cb(self, button):
+        self._axis_pos_x_dialog.show_all()
+
+    def _axis_pos_y_button_clicked_cb(self, button):
+        self._axis_pos_y_dialog.show_all()
+
+    def _symmetry_type_combo_changed_cb(self, *ignored):
+        rootstack = self.app.doc.model.layer_stack
+        model = self._symmetry_type_combo.get_model()
+        mode = model.get_value(self._symmetry_type_combo.get_active_iter(), 0)
+
+        if rootstack.symmetry_type == mode:
+            return
+        rootstack.symmetry_type = mode
 
     def _axis_pos_dialog_response_cb(self, dialog, response_id):
         if response_id == Gtk.ResponseType.ACCEPT:
@@ -500,7 +720,7 @@ class SymmetryOverlay (gui.overlays.Overlay):
         doc.modes.changed += self._active_mode_changed_cb
         self._trash_icon_pixbuf = None
 
-    def _symmetry_state_changed_cb(self, rootstack, active, x):
+    def _symmetry_state_changed_cb(self, rootstack, active, x, y, symmetry_type, rot_symmetry_lines):
         self.tdw.queue_draw()
 
     def _active_mode_changed_cb(self, mode_stack, old, new):
@@ -516,7 +736,10 @@ class SymmetryOverlay (gui.overlays.Overlay):
         model = self.doc.model
         if not model.layer_stack.symmetry_active:
             return
-        axis_x_m = model.layer_stack.symmetry_axis
+        axis_x_m = model.layer_stack.symmetry_x
+        axis_y_m = model.layer_stack.symmetry_y
+        axis_symmetry_type = model.layer_stack.symmetry_type
+        axis_rot_symmetry_lines = model.layer_stack.rot_symmetry_lines
 
         # allocation, in display coords
         alloc = self.tdw.get_allocation()
@@ -537,26 +760,55 @@ class SymmetryOverlay (gui.overlays.Overlay):
         ]
 
         # Viewport extent in x in model space
+        min_corner_x_m = min([c_m[0] for c_m in viewport_corners_m])
+        max_corner_x_m = max([c_m[0] for c_m in viewport_corners_m])
         min_corner_y_m = min([c_m[1] for c_m in viewport_corners_m])
         max_corner_y_m = max([c_m[1] for c_m in viewport_corners_m])
-        axis_p_min = (axis_x_m, min_corner_y_m)
-        axis_p_max = (axis_x_m, max_corner_y_m)
 
-        # The two places where the axis intersects the viewing rectangle
-        intersections = [
-            lib.alg.intersection_of_segments(p1, p2, axis_p_min, axis_p_max)
-            for (p1, p2) in lib.alg.pairwise(viewport_corners_m)
-        ]
+        # symmetry axes extents
+        axis_x_p_min = (axis_x_m, min_corner_y_m)
+        axis_x_p_max = (axis_x_m, max_corner_y_m)
+        axis_y_p_min = (min_corner_x_m, axis_y_m)
+        axis_y_p_max = (max_corner_x_m, axis_y_m)
+
+        # The places where the axes intersect the viewing rectangle
+        if axis_symmetry_type == lib.mypaintlib.SymmetryVertical:
+            intersections = [
+                lib.alg.intersection_of_segments(p1, p2, axis_x_p_min, axis_x_p_max)
+                for (p1, p2) in lib.alg.pairwise(viewport_corners_m)
+            ]
+        elif axis_symmetry_type == lib.mypaintlib.SymmetryHorizontal:
+            intersections = [
+                lib.alg.intersection_of_segments(p1, p2, axis_y_p_min, axis_y_p_max)
+                for (p1, p2) in lib.alg.pairwise(viewport_corners_m)
+            ]
+        else:
+            intersections = []
+            axes_extents_m = [
+                axis_x_p_min, axis_x_p_max,
+                axis_y_p_min, axis_y_p_max,
+            ]
+            for axes_extent_m1, axes_extent_m2 in lib.helpers.grouper(axes_extents_m, 2):
+                for (p1, p2) in lib.alg.pairwise(viewport_corners_m):
+                    intersections.append(
+                        lib.alg.intersection_of_segments(p1, p2, axes_extent_m1, axes_extent_m2)
+                    )
+
         intersections = [p for p in intersections if p is not None]
-        if len(intersections) != 2:
+
+        len_intersections = len(intersections)
+
+        if len_intersections < 2:
             return
-        intsc0_m, intsc1_m = intersections
+
+        if len_intersections % 2 == 1:
+            intersections.pop()
 
         # Back to display coords, with rounding and pixel centring
-        ax_x0, ax_y0 = [math.floor(c) for c in
-                        self.tdw.model_to_display(*intsc0_m)]
-        ax_x1, ax_y1 = [math.floor(c) for c in
-                        self.tdw.model_to_display(*intsc1_m)]
+        ax_points = []
+        for intsc_m in intersections:
+            ax_point = tuple((math.floor(c) for c in self.tdw.model_to_display(*intsc_m)))
+            ax_points.append(ax_point)
 
         # Paint the symmetry axis
         cr.save()
@@ -581,7 +833,7 @@ class SymmetryOverlay (gui.overlays.Overlay):
         if not active_edit_mode:
             line_color = gui.style.EDITABLE_ITEM_COLOR
             line_alpha = min_alpha
-        elif mode.zone == _EditZone.MOVE_AXIS:
+        elif mode.zone in {_EditZone.MOVE_X_AXIS, _EditZone.MOVE_Y_AXIS}:
             line_color = gui.style.ACTIVE_ITEM_COLOR
             line_alpha = max_alpha
         else:
@@ -592,17 +844,18 @@ class SymmetryOverlay (gui.overlays.Overlay):
 
         line_width = gui.style.DRAGGABLE_EDGE_WIDTH
         if line_width % 2 != 0:
-            ax_x0 += 0.5
-            ax_y0 += 0.5
-            ax_x1 += 0.5
-            ax_y1 += 0.5
+            for ax_point in ax_points:
+                ax_point[0] += 0.5
+                ax_point[1] += 0.5
 
-        cr.move_to(ax_x0, ax_y0)
-        cr.line_to(ax_x1, ax_y1)
         cr.set_line_width(line_width)
-        gui.drawutils.render_drop_shadow(cr, z=1)
         cr.set_source_rgb(*line_color.get_rgb())
-        cr.stroke()
+
+        for ax_point, ax_point2 in lib.helpers.grouper(ax_points, 2):
+            cr.move_to(*ax_point2)
+            cr.line_to(*ax_point)
+            gui.drawutils.render_drop_shadow(cr, z=1)
+            cr.stroke()
 
         cr.pop_group_to_source()
         cr.paint_with_alpha(line_alpha)
@@ -616,6 +869,22 @@ class SymmetryOverlay (gui.overlays.Overlay):
 
         # Positioning strategy: the point on the axis line
         # which is closest to the centre of the viewport.
+        if axis_symmetry_type == lib.mypaintlib.SymmetryVertical:
+            ax_x0, ax_y0 = ax_points[0]
+            ax_x1, ax_y1 = ax_points[1]
+        elif axis_symmetry_type == lib.mypaintlib.SymmetryHorizontal:
+            ax_x0, ax_y0 = ax_points[0]
+            ax_x1, ax_y1 = ax_points[1]
+        else:
+            x_axis_dist = abs(ax_points[0][0] - view_center[0])/alloc.width
+            y_axis_dist = abs(ax_points[-1][1] - view_center[1])/alloc.height
+            if y_axis_dist < x_axis_dist:
+                ax_x0, ax_y0 = ax_points[-1]
+                ax_x1, ax_y1 = ax_points[-2]
+            else:
+                ax_x0, ax_y0 = ax_points[0]
+                ax_x1, ax_y1 = ax_points[1]
+
         button_pos = lib.alg.nearest_point_in_segment(
             seg_start=(ax_x0, ax_y0),
             seg_end=(ax_x1, ax_y1),

--- a/gui/symmetry.py
+++ b/gui/symmetry.py
@@ -377,7 +377,7 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
     )
     _SYMMETRY_ROT_LINES_TEXT = C_(
         "symmetry axis options panel: labels",
-        u"Number of rotational lines:",
+        u"Rotational lines:",
     )
 
     def __init__(self):

--- a/gui/symmetry.py
+++ b/gui/symmetry.py
@@ -842,13 +842,10 @@ class SymmetryOverlay (gui.overlays.Overlay):
         max_alpha = 1.0
 
         if not active_edit_mode:
-            line_color = gui.style.EDITABLE_ITEM_COLOR
             line_alpha = min_alpha
         elif mode.zone in {_EditZone.MOVE_X_AXIS, _EditZone.MOVE_Y_AXIS}:
-            line_color = gui.style.ACTIVE_ITEM_COLOR
             line_alpha = max_alpha
         else:
-            line_color = gui.style.EDITABLE_ITEM_COLOR
             line_alpha = min_alpha + (
                 active_edit_mode.line_alphafrac * (max_alpha-min_alpha)
             )
@@ -860,9 +857,23 @@ class SymmetryOverlay (gui.overlays.Overlay):
                 ax_point[1] += 0.5
 
         cr.set_line_width(line_width)
-        cr.set_source_rgb(*line_color.get_rgb())
 
         for ax_point, ax_point2 in lib.helpers.grouper(ax_points, 2):
+            if ax_point[0] == ax_point2[0]:
+                if mode.zone == _EditZone.MOVE_X_AXIS:
+                    line_color = gui.style.ACTIVE_ITEM_COLOR
+                else:
+                    line_color = gui.style.EDITABLE_ITEM_COLOR
+            elif ax_point[1] == ax_point2[1]:
+                if mode.zone == _EditZone.MOVE_Y_AXIS:
+                    line_color = gui.style.ACTIVE_ITEM_COLOR
+                else:
+                    line_color = gui.style.EDITABLE_ITEM_COLOR
+            else:
+                line_color = gui.style.EDITABLE_ITEM_COLOR
+
+            cr.set_source_rgb(*line_color.get_rgb())
+
             cr.move_to(*ax_point2)
             cr.line_to(*ax_point)
             gui.drawutils.render_drop_shadow(cr, z=1)

--- a/gui/symmetry.py
+++ b/gui/symmetry.py
@@ -532,7 +532,13 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
         sym_types = lib.tiledsurface.SYMMETRY_TYPES
         active_idx = 0
         rootstack = self.app.doc.model.layer_stack
-        starts_with_rotate = (rootstack.symmetry_type == lib.mypaintlib.SymmetryRotational)
+        starts_with_rotate = (
+            rootstack.symmetry_type in
+            {
+                lib.mypaintlib.SymmetryRotational,
+                lib.mypaintlib.SymmetrySnowflake,
+            }
+        )
         for i, sym_type in enumerate(sym_types):
             label = lib.tiledsurface.SYMMETRY_STRINGS.get(sym_type)
             store.append([sym_type, label])
@@ -632,7 +638,12 @@ class SymmetryEditOptionsWidget (Gtk.Alignment):
             if adj_pos != model_pos:
                 adj.set_value(model_pos)
 
-        if symmetry_type in {lib.mypaintlib.SymmetryRotational, None}:
+        rotational_allowed = {
+            lib.mypaintlib.SymmetryRotational,
+            lib.mypaintlib.SymmetrySnowflake,
+            None,
+        }
+        if symmetry_type in rotational_allowed:
             self._axis_rot_sym_lines_entry.set_sensitive(True)
         else:
             self._axis_rot_sym_lines_entry.set_sensitive(False)

--- a/gui/symmetry.py
+++ b/gui/symmetry.py
@@ -859,7 +859,9 @@ class SymmetryOverlay (gui.overlays.Overlay):
         cr.set_line_width(line_width)
 
         for ax_point, ax_point2 in lib.helpers.grouper(ax_points, 2):
-            if ax_point[0] == ax_point2[0]:
+            if not active_edit_mode:
+                line_color = gui.style.EDITABLE_ITEM_COLOR
+            elif ax_point[0] == ax_point2[0]:
                 if mode.zone == _EditZone.MOVE_X_AXIS:
                     line_color = gui.style.ACTIVE_ITEM_COLOR
                 else:

--- a/lib/document.py
+++ b/lib/document.py
@@ -788,7 +788,7 @@ class Document (object):
         and resets the frame and the stored resolution.
         """
         self.sync_pending_changes()
-        self._layers.set_symmetry_state(False, None, None, lib.mypaintlib.SymmetryVertical, 1)
+        self._layers.set_symmetry_state(False, None, None, lib.mypaintlib.SymmetryVertical, 2)
         prev_area = self.get_full_redraw_bbox()
         if self._cache_dir is not None:
             self._cleanup_cache_dir()

--- a/lib/document.py
+++ b/lib/document.py
@@ -788,7 +788,7 @@ class Document (object):
         and resets the frame and the stored resolution.
         """
         self.sync_pending_changes()
-        self._layers.set_symmetry_state(False, None)
+        self._layers.set_symmetry_state(False, None, None, lib.mypaintlib.SymmetryVertical, 1)
         prev_area = self.get_full_redraw_bbox()
         if self._cache_dir is not None:
             self._cleanup_cache_dir()

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -9,6 +9,7 @@
 
 from __future__ import division, print_function
 
+from itertools import izip_longest
 from math import floor, isnan
 import os
 import hashlib
@@ -529,6 +530,22 @@ def fmt_time_period_abbr(t):
         seconds = seconds,
     )
 
+def grouper(iterable, n, fillvalue=None):
+    """Collect data into fixed-length chunks or blocks
+
+    :param iterable: An iterable
+    :param int n: How many items to chunk the iterator by
+    :param fillvalue: Filler value when iterable length isn't a multiple of n
+    :returns: An iterable with tuples n items from the source iterable
+    :rtype: iterable
+
+    >>> actual = grouper('ABCDEFG', 3, fillvalue='x')
+    >>> expected = [('A', 'B', 'C'), ('D', 'E', 'F'), ('G', 'x', 'x')]
+    >>> [a_val == e_val for a_val, e_val in zip(actual, expected)]
+    [True, True, True]
+    """
+    args = [iter(iterable)] * n
+    return izip_longest(*args, fillvalue=fillvalue)
 
 def _test():
     import doctest

--- a/lib/layer/core.py
+++ b/lib/layer/core.py
@@ -930,7 +930,7 @@ class LayerBase (TileBlittable, TileCompositable):
 
     ## Painting symmetry axis
 
-    def set_symmetry_state(self, active, center_x):
+    def set_symmetry_state(self, active, center_x, center_y, symmetry_type, rot_symmetry_lines):
         """Set the surface's painting symmetry axis and active flag.
 
         :param bool active: Whether painting should be symmetrical.

--- a/lib/layer/core.py
+++ b/lib/layer/core.py
@@ -935,6 +935,10 @@ class LayerBase (TileBlittable, TileCompositable):
 
         :param bool active: Whether painting should be symmetrical.
         :param int center_x: X coord of the axis of symmetry.
+        :param int center_y: Y coord of the axis of symmetry.
+        :param int symmetry_type: symmetry type that will be applied if active
+        :param int rot_symmetry_lines: number of rotational
+            symmetry lines for angle dependent symmetry modes.
 
         The symmetry axis is only meaningful to paintable layers.
         Received strokes are reflected along the line ``x=center_x``

--- a/lib/layer/data.py
+++ b/lib/layer/data.py
@@ -467,12 +467,14 @@ class SurfaceBackedLayer (core.LayerBase, lib.autosave.Autosaveable):
 
     ## Painting symmetry axis
 
-    def set_symmetry_state(self, active, center_x):
+    def set_symmetry_state(self, active, center_x, center_y, symmetry_type, rot_symmetry_lines):
         """Set the surface's painting symmetry axis and active flag.
 
         See `LayerBase.set_symmetry_state` for the params.
         """
-        self._surface.set_symmetry_state(bool(active), float(center_x))
+        self._surface.set_symmetry_state(bool(active),
+                                float(center_x), float(center_y),
+                                int(symmetry_type), int(rot_symmetry_lines))
 
     ## Snapshots
 

--- a/lib/layer/tree.py
+++ b/lib/layer/tree.py
@@ -573,7 +573,7 @@ class RootLayerStack (group.LayerStack):
         self._symmetry_x = center_x
         self._symmetry_y = center_y
         self._symmetry_type = symmetry_type
-        self._rot_symmetry_lines = max(rot_symmetry_lines, 2)
+        self._rot_symmetry_lines = rot_symmetry_lines
         current = self.get_current()
         if current is not self:
             self._propagate_symmetry_state(current)

--- a/lib/layer/tree.py
+++ b/lib/layer/tree.py
@@ -513,14 +513,26 @@ class RootLayerStack (group.LayerStack):
         if x is None:
             self.set_symmetry_state(False, None, None, None, None)
         else:
-            self.set_symmetry_state(True, x, self._symmetry_y, self._symmetry_type, self._rot_symmetry_lines)
+            self.set_symmetry_state(
+                True,
+                x,
+                self._symmetry_y,
+                self._symmetry_type,
+                self._rot_symmetry_lines
+            )
 
     @symmetry_y.setter
     def symmetry_y(self, y):
         if y is None:
             self.set_symmetry_state(False, None, None, None, None)
         else:
-            self.set_symmetry_state(True, self._symmetry_x, y, self._symmetry_type, self._rot_symmetry_lines)
+            self.set_symmetry_state(
+                True,
+                self._symmetry_x,
+                y,
+                self._symmetry_type,
+                self._rot_symmetry_lines
+            )
 
     @property
     def symmetry_type(self):
@@ -531,7 +543,13 @@ class RootLayerStack (group.LayerStack):
         if symmetry_type is None:
             self.set_symmetry_state(False, None, None, None, None)
         else:
-            self.set_symmetry_state(True, self._symmetry_x, self._symmetry_y, symmetry_type, self._rot_symmetry_lines)
+            self.set_symmetry_state(
+                True,
+                self._symmetry_x,
+                self._symmetry_y,
+                symmetry_type,
+                self._rot_symmetry_lines
+            )
 
     @property
     def rot_symmetry_lines(self):
@@ -542,7 +560,13 @@ class RootLayerStack (group.LayerStack):
         if rot_symmetry_lines is None:
             self.set_symmetry_state(False, None, None, None, None)
         else:
-            self.set_symmetry_state(True, self._symmetry_x, self._symmetry_y, self._symmetry_type, rot_symmetry_lines)
+            self.set_symmetry_state(
+                True,
+                self._symmetry_x,
+                self._symmetry_y,
+                self._symmetry_type,
+                rot_symmetry_lines
+            )
 
     def set_symmetry_state(self, active, center_x, center_y, symmetry_type, rot_symmetry_lines):
         """Set the central, propagated, symmetry axis and active flag.
@@ -565,8 +589,20 @@ class RootLayerStack (group.LayerStack):
         if rot_symmetry_lines is not None:
             rot_symmetry_lines = int(rot_symmetry_lines)
 
-        oldstate = (self._symmetry_active, self._symmetry_x, self._symmetry_y, self._symmetry_type, self._rot_symmetry_lines)
-        newstate = (active, center_x, center_y, symmetry_type, rot_symmetry_lines)
+        oldstate = (
+            self._symmetry_active,
+            self._symmetry_x,
+            self._symmetry_y,
+            self._symmetry_type,
+            self._rot_symmetry_lines,
+        )
+        newstate = (
+            active,
+            center_x,
+            center_y,
+            symmetry_type,
+            rot_symmetry_lines,
+        )
         if oldstate == newstate:
             return
         self._symmetry_active = active
@@ -577,12 +613,18 @@ class RootLayerStack (group.LayerStack):
         current = self.get_current()
         if current is not self:
             self._propagate_symmetry_state(current)
-        self.symmetry_state_changed(active, center_x, center_y, symmetry_type, rot_symmetry_lines)
+        self.symmetry_state_changed(
+            active,
+            center_x,
+            center_y,
+            symmetry_type,
+            rot_symmetry_lines
+        )
 
     def _propagate_symmetry_state(self, layer):
         """Copy the symmetry state to the a descendant layer"""
         assert layer is not self
-        if self._symmetry_x is None or self._symmetry_y is None or self._symmetry_type is None:
+        if None in {self._symmetry_x, self._symmetry_y, self._symmetry_type}:
             return
         layer.set_symmetry_state(
             self._symmetry_active,

--- a/lib/tiledsurface.hpp
+++ b/lib/tiledsurface.hpp
@@ -15,6 +15,7 @@ enum SymmetryType
         SymmetryHorizontal,
         SymmetryVertHorz,
         SymmetryRotational,
+        SymmetrySnowflake,
         NumSymmetryTypes
 };
 

--- a/lib/tiledsurface.hpp
+++ b/lib/tiledsurface.hpp
@@ -9,6 +9,15 @@
 
 #include <mypaint-tiled-surface.h>
 
+enum SymmetryType
+{
+        SymmetryVertical,
+        SymmetryHorizontal,
+        SymmetryVertHorz,
+        SymmetryRotational,
+        NumSymmetryTypes
+};
+
 static const int TILE_SIZE = MYPAINT_TILE_SIZE;
 static const int MAX_MIPMAP_LEVEL = MYPAINT_MAX_MIPMAP_LEVEL;
 
@@ -31,8 +40,12 @@ public:
       mypaint_surface_unref((MyPaintSurface *)c_surface);
   }
 
-  void set_symmetry_state(bool active, float center_x) {
-    mypaint_tiled_surface_set_symmetry_state((MyPaintTiledSurface *)c_surface, active, center_x);
+  void set_symmetry_state(bool active,
+        float center_x, float center_y,
+        enum SymmetryType symmetry_type, int rot_symmetry_lines) {
+    mypaint_tiled_surface_set_symmetry_state((MyPaintTiledSurface *)c_surface, active,
+        center_x, center_y,
+        (MyPaintSymmetryType)symmetry_type, rot_symmetry_lines);
   }
 
   void begin_atomic() {

--- a/lib/tiledsurface.py
+++ b/lib/tiledsurface.py
@@ -22,6 +22,7 @@ from gettext import gettext as _
 import numpy as np
 
 import mypaintlib
+import lib.mypaintlib
 import helpers
 import math
 import pixbufsurface
@@ -37,6 +38,15 @@ import lib.modes
 TILE_SIZE = N = mypaintlib.TILE_SIZE
 MAX_MIPMAP_LEVEL = mypaintlib.MAX_MIPMAP_LEVEL
 
+SYMMETRY_TYPES = tuple(range(lib.mypaintlib.NumSymmetryTypes))
+SYMMETRY_STRINGS = {
+    lib.mypaintlib.SymmetryVertical:    _("Vertical"),
+    lib.mypaintlib.SymmetryHorizontal:  _("Horizontal"),
+    lib.mypaintlib.SymmetryVertHorz:    _("Vertical and horizontal"),
+    lib.mypaintlib.SymmetryRotational:  _("Rotational"),
+}
+for sym_type in SYMMETRY_TYPES:
+    assert sym_type in SYMMETRY_STRINGS
 
 ## Tile class and marker tile constants
 

--- a/lib/tiledsurface.py
+++ b/lib/tiledsurface.py
@@ -44,6 +44,7 @@ SYMMETRY_STRINGS = {
     lib.mypaintlib.SymmetryHorizontal:  _("Horizontal"),
     lib.mypaintlib.SymmetryVertHorz:    _("Vertical and horizontal"),
     lib.mypaintlib.SymmetryRotational:  _("Rotational"),
+    lib.mypaintlib.SymmetrySnowflake:   _("Snowflake"),
 }
 for sym_type in SYMMETRY_TYPES:
     assert sym_type in SYMMETRY_STRINGS


### PR DESCRIPTION
Implements #529 .

The reason why the [RFC] is in the pull request title is that I was working on getting this into a presentable, working state before asking for comments on the implementation.

The following commits implement horizontal, horizontal + vertical, rotational, and snowflake symmetry.

That being said, I'm fairly happy with how I implemented the UI. It's mostly straightforward.

I'm just confused at how I should handle the spinbox for the rotational symmetry lines. Without me adjusting the code for the alternative symmetry modes, the dialog box for mypaint's symmetry X axis isn't insensitive when symmetry is disabled. Is this intended? If not, I'll adjust the symmetry UI code to respond properly when symmetry is disabled.

Further commits here are likely going to be stylistic touches to adhere to the Python Style guide.

If pulled, it should only be pulled at the same time with https://github.com/mypaint/libmypaint/pull/57 to ensure the code builds.
