### PR TITLE
Brush inputs/settings calibrated for viewzoom and viewrotation [WIP]

### DIFF
--- a/gui/drawutils.py
+++ b/gui/drawutils.py
@@ -40,14 +40,14 @@ from lib.pixbufsurface import render_as_pixbuf
 ## Module constants
 
 _BRUSH_PREVIEW_POINTS = [
-    # px,  py,   press, xtilt, ytilt  # px,  py,   press, xtilt, ytilt
-    (0.00, 0.00,  0.00,  0.00, 0.00), (1.00, 0.05,  0.00, -0.06, 0.05),
-    (0.10, 0.10,  0.20,  0.10, 0.05), (0.90, 0.15,  0.90, -0.05, 0.05),
-    (0.11, 0.30,  0.90,  0.08, 0.05), (0.86, 0.35,  0.90, -0.04, 0.05),
-    (0.13, 0.50,  0.90,  0.06, 0.05), (0.84, 0.55,  0.90, -0.03, 0.05),
-    (0.17, 0.70,  0.90,  0.04, 0.05), (0.83, 0.75,  0.90, -0.02, 0.05),
-    (0.25, 0.90,  0.20,  0.02, 0.00), (0.81, 0.95,  0.00,  0.00, 0.00),
-    (0.41, 0.95,  0.00,  0.00, 0.00), (0.80, 1.00,  0.00,  0.00, 0.00),
+    # px,  py,   press, xtilt, ytilt, viewzoom, viewrotation  # px,  py,   press, xtilt, ytilt, viewzoom, viewrotation
+    (0.00, 0.00,  0.00,  0.00, 0.00, 1.00, 0.00), (1.00, 0.05,  0.00, -0.06, 0.05, 1.00, 0.00),
+    (0.10, 0.10,  0.20,  0.10, 0.05, 1.00, 0.00), (0.90, 0.15,  0.90, -0.05, 0.05, 1.00, 0.00),
+    (0.11, 0.30,  0.90,  0.08, 0.05, 1.00, 0.00), (0.86, 0.35,  0.90, -0.04, 0.05, 1.00, 0.00),
+    (0.13, 0.50,  0.90,  0.06, 0.05, 1.00, 0.00), (0.84, 0.55,  0.90, -0.03, 0.05, 1.00, 0.00),
+    (0.17, 0.70,  0.90,  0.04, 0.05, 1.00, 0.00), (0.83, 0.75,  0.90, -0.02, 0.05, 1.00, 0.00),
+    (0.25, 0.90,  0.20,  0.02, 0.00, 1.00, 0.00), (0.81, 0.95,  0.00,  0.00, 0.00, 1.00, 0.00),
+    (0.41, 0.95,  0.00,  0.00, 0.00, 1.00, 0.00), (0.80, 1.00,  0.00,  0.00, 0.00, 1.00, 0.00),
 ]
 
 
@@ -113,19 +113,19 @@ def spline_iter(tuples, double_first=True, double_last=True):
 
 def _variable_pressure_scribble(w, h, tmult):
     points = _BRUSH_PREVIEW_POINTS
-    px, py, press, xtilt, ytilt = points[0]
-    yield (10, px*w, py*h, 0.0, xtilt, ytilt)
+    px, py, press, xtilt, ytilt, viewzoom, viewrotation = points[0]
+    yield (10, px*w, py*h, 0.0, xtilt, ytilt,viewzoom, viewrotation)
     event_dtime = 0.005
     point_time = 0.1
-    for p_1, p0, p1, p2 in spline_iter(points, True, True):
+    for p_1, p0, p1, p2, p3, p4 in spline_iter(points, True, True):
         dt = 0.0
         while dt < point_time:
             t = dt/point_time
-            px, py, press, xtilt, ytilt = spline_4p(t, p_1, p0, p1, p2)
-            yield (event_dtime, px*w, py*h, press, xtilt, ytilt)
+            px, py, press, xtilt, ytilt, viewzoom, viewrotation = spline_4p(t, p_1, p0, p1, p2, p3, p4)
+            yield (event_dtime, px*w, py*h, press, xtilt, ytilt, viewzoom, viewrotation)
             dt += event_dtime
-    px, py, press, xtilt, ytilt = points[-1]
-    yield (10, px*w, py*h, 0.0, xtilt, ytilt)
+    px, py, press, xtilt, ytilt, viewzoom, viewrotation = points[-1]
+    yield (10, px*w, py*h, 0.0, xtilt, ytilt, viewzoom, viewrotation)
 
 
 def render_brush_preview_pixbuf(brushinfo, max_edge_tiles=4):

--- a/gui/freehand.py
+++ b/gui/freehand.py
@@ -555,6 +555,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
             tilt_magnitude = math.sqrt((xtilt**2) + (ytilt**2))
             xtilt = tilt_magnitude * math.cos(tilt_angle)
             ytilt = tilt_magnitude * math.sin(tilt_angle)
+
         # HACK: color picking, do not paint
         # TEST: Does this ever happen now?
         if (state & Gdk.ModifierType.CONTROL_MASK or

--- a/gui/freehand.py
+++ b/gui/freehand.py
@@ -555,7 +555,6 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
             tilt_magnitude = math.sqrt((xtilt**2) + (ytilt**2))
             xtilt = tilt_magnitude * math.cos(tilt_angle)
             ytilt = tilt_magnitude * math.sin(tilt_angle)
-	
         # HACK: color picking, do not paint
         # TEST: Does this ever happen now?
         if (state & Gdk.ModifierType.CONTROL_MASK or

--- a/gui/freehand.py
+++ b/gui/freehand.py
@@ -181,7 +181,6 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
             self.last_good_raw_pressure = 0.0
             self.last_good_raw_xtilt = 0.0
             self.last_good_raw_ytilt = 0.0
-            self.last_good_raw_rotation = 0.0
 
         def queue_motion(self, event_data):
             """Append one raw motion event to the motion queue
@@ -190,7 +189,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
             :type event_data: tuple
 
             Events are tuples of the form ``(time, x, y, pressure,
-            xtilt, ytilt, rotation)``. Times are in milliseconds, and are
+            xtilt, ytilt)``. Times are in milliseconds, and are
             expressed as ints. ``x`` and ``y`` are ordinary Python
             floats, and refer to model coordinates. The pressure and
             tilt values have the meaning assigned to them by GDK; if
@@ -199,7 +198,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
 
             Zero-dtime events are detected and cleaned up here.
             """
-            time, x, y, pressure, xtilt, ytilt, rotation = event_data
+            time, x, y, pressure, xtilt, ytilt = event_data
             if time < self._last_queued_event_time:
                 logger.warning('Time is running backwards! Corrected.')
                 time = self._last_queued_event_time
@@ -208,7 +207,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
                 # On Windows, GTK timestamps have a resolution around
                 # 15ms, but tablet events arrive every 8ms.
                 # https://gna.org/bugs/index.php?16569
-                zdata = (x, y, pressure, xtilt, ytilt, rotation)
+                zdata = (x, y, pressure, xtilt, ytilt)
                 self._zero_dtime_motions.append(zdata)
             else:
                 # Queue any previous events that had identical
@@ -224,9 +223,9 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
                         zt = self._last_queued_event_time
                         interval = float(dtime)
                     step = interval / (len(self._zero_dtime_motions) + 1)
-                    for zx, zy, zp, zxt, zyt, zrt in self._zero_dtime_motions:
+                    for zx, zy, zp, zxt, zyt in self._zero_dtime_motions:
                         zt += step
-                        zevent_data = (zt, zx, zy, zp, zxt, zyt, zrt)
+                        zevent_data = (zt, zx, zy, zp, zxt, zyt)
                         self.motion_queue.append(zevent_data)
                     # Reset the backlog buffer
                     self._zero_dtime_motions = []
@@ -397,7 +396,6 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
             drawstate.last_good_raw_pressure = 0.0
             drawstate.last_good_raw_xtilt = 0.0
             drawstate.last_good_raw_ytilt = 0.0
-            drawstate.last_good_raw_rotation = 0.0
 
             # Hide the cursor if configured to
             self._hide_drawing_cursor(tdw)
@@ -421,7 +419,6 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
             drawstate.last_good_raw_pressure = 0.0
             drawstate.last_good_raw_xtilt = 0.0
             drawstate.last_good_raw_ytilt = 0.0
-            drawstate.last_good_raw_rotation = 0.0
 
             # Reinstate the normal cursor if it was hidden
             self._reinstate_drawing_cursor(tdw)
@@ -483,7 +480,6 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
         pressure = event.get_axis(Gdk.AxisUse.PRESSURE)
         xtilt = event.get_axis(Gdk.AxisUse.XTILT)
         ytilt = event.get_axis(Gdk.AxisUse.YTILT)
-        rotation = event.get_axis(Gdk.AxisUse.WHEEL)
         state = event.state
 
         # Workaround for buggy evdev behaviour.
@@ -497,12 +493,6 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
                 pressure = drawstate.last_good_raw_pressure
             elif pressure is not None and np.isfinite(pressure):
                 drawstate.last_good_raw_pressure = pressure
-
-	#If WHEEL is missing (rotation)
-	if rotation is None:
-            rotation = 0.0
-
-
 
         # Ensure each non-evhack event has a defined pressure
         if pressure is not None:
@@ -595,7 +585,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
             if (hx0, hy0, ht0) == (x, y, time):
                 for hx, hy, ht in drawstate.evhack_positions:
                     hx, hy = tdw.display_to_model(hx, hy)
-                    event_data = (ht, hx, hy, None, None, None, None)
+                    event_data = (ht, hx, hy, None, None, None)
                     drawstate.queue_motion(event_data)
             else:
                 logger.warning(
@@ -609,7 +599,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
 
         # Queue this event
         x, y = tdw.display_to_model(x, y)
-        event_data = (time, x, y, pressure, xtilt, ytilt, rotation)
+        event_data = (time, x, y, pressure, xtilt, ytilt)
         drawstate.queue_motion(event_data)
         # Start the motion event processor, if it isn't already running
         if not drawstate.motion_processing_cbid:
@@ -642,7 +632,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
     def _process_queued_event(self, tdw, event_data):
         """Process one motion event from the motion queue"""
         drawstate = self._get_drawing_state(tdw)
-        time, x, y, pressure, xtilt, ytilt, rotation = event_data
+        time, x, y, pressure, xtilt, ytilt = event_data
         model = tdw.doc
 
         # Calculate time delta for the brush engine
@@ -681,7 +671,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
         pressure = clamp(pressure, 0.0, 1.0)
         xtilt = clamp(xtilt, -1.0, 1.0)
         ytilt = clamp(ytilt, -1.0, 1.0)
-        self.stroke_to(model, dtime, x, y, pressure, xtilt, ytilt, rotation)
+        self.stroke_to(model, dtime, x, y, pressure, xtilt, ytilt)
 
         # Update the TDW's idea of where we last painted
         # FIXME: this should live in the model, not the view
@@ -883,7 +873,7 @@ class PressureAndTiltInterpolator (object):
 
     # Public methods:
 
-    def feed(self, time, x, y, pressure, xtilt, ytilt, rotation):
+    def feed(self, time, x, y, pressure, xtilt, ytilt):
         """Feed in an event, yielding zero or more interpolated events
 
         :param time: event timestamp, integer number of milliseconds
@@ -894,17 +884,16 @@ class PressureAndTiltInterpolator (object):
         :param pressure: Effective pen pressure, [0.0, 1.0]
         :param xtilt: Pen tilt in the model X direction, [-1.0, 1.0]
         :param ytilt: Pen tilt in the model's Y direction, [-1.0, 1.0]
-        :param rotation: Pen rotation, [-900.0, 900.0]
         :returns: Iterator of event tuples
 
-        Event tuples have the form (TIME, X, Y, PRESSURE, XTILT, YTILT, ROTATION).
+        Event tuples have the form (TIME, X, Y, PRESSURE, XTILT, YTILT).
         """
-        if None in (pressure, xtilt, ytilt, rotation):
-            self._np_next.append((time, x, y, pressure, xtilt, ytilt, rotation))
+        if None in (pressure, xtilt, ytilt):
+            self._np_next.append((time, x, y, pressure, xtilt, ytilt))
         else:
-            self._pt1_next = (time, x, y, pressure, xtilt, ytilt, rotation)
-            for t, x, y, p, xt, yt, rt in self._interpolate_and_step():
-                yield (t, x, y, p, xt, yt, rt)
+            self._pt1_next = (time, x, y, pressure, xtilt, ytilt)
+            for t, x, y, p, xt, yt in self._interpolate_and_step():
+                yield (t, x, y, p, xt, yt)
 
 
 ## Module tests
@@ -914,7 +903,7 @@ def _test():
     doctest.testmod()
     interp = PressureAndTiltInterpolator()
     # Emit CSV for ad-hoc plotting
-    print("time,x,y,pressure,xtilt,ytilt,rotation")
+    print("time,x,y,pressure,xtilt,ytilt")
     for event in interp._TEST_DATA:
         for data in interp.feed(*event):
             print(",".join([str(c) for c in data]))

--- a/gui/inktool.py
+++ b/gui/inktool.py
@@ -42,7 +42,7 @@ class _Phase:
     ADJUST = 1
 
 
-_NODE_FIELDS = ("x", "y", "pressure", "xtilt", "ytilt", "time")
+_NODE_FIELDS = ("x", "y", "pressure", "xtilt", "ytilt", "time", "viewzoom", "viewrotation")
 
 
 class _Node (collections.namedtuple("_Node", _NODE_FIELDS)):
@@ -54,6 +54,8 @@ class _Node (collections.namedtuple("_Node", _NODE_FIELDS)):
     * pressure: float in [0.0, 1.0]
     * xtilt, ytilt: float in [-1.0, 1.0]
     * time: absolute seconds, float
+    * viewzoom: current zoom level [0.0, 64]
+    * viewrotation: current view rotation [-180.0, 180.0]
     """
 
 
@@ -151,6 +153,8 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         self._last_good_raw_pressure = 0.0
         self._last_good_raw_xtilt = 0.0
         self._last_good_raw_ytilt = 0.0
+        self._last_good_raw_viewzoom = 0.0
+        self._last_good_raw_viewrotation = 0.0
 
     def _reset_nodes(self):
         self.nodes = []  # nodes that met the distance+time criteria
@@ -282,6 +286,8 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         self._last_good_raw_pressure = 0.0
         self._last_good_raw_xtilt = 0.0
         self._last_good_raw_ytilt = 0.0
+        self._last_good_raw_viewzoom = 0.0
+        self._last_good_raw_viewrotation = 0.0
         # Supercall: start drags etc
         return super(InkingMode, self).button_press_cb(tdw, event)
 
@@ -317,6 +323,8 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         self._last_good_raw_pressure = 0.0
         self._last_good_raw_xtilt = 0.0
         self._last_good_raw_ytilt = 0.0
+        self._last_good_raw_viewzoom = 0.0
+        self._last_good_raw_viewrotation = 0.0
         # Supercall: stop current drag
         return super(InkingMode, self).button_release_cb(tdw, event)
 
@@ -476,14 +484,16 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         for i in xrange(int(steps) + 1):
             t = i / steps
             point = gui.drawutils.spline_4p(t, p_1, p0, p1, p2)
-            x, y, pressure, xtilt, ytilt, t_abs = point
+            x, y, pressure, xtilt, ytilt, t_abs, viewzoom, viewrotation = point
             pressure = lib.helpers.clamp(pressure, 0.0, 1.0)
             xtilt = lib.helpers.clamp(xtilt, -1.0, 1.0)
             ytilt = lib.helpers.clamp(ytilt, -1.0, 1.0)
             t_abs = max(last_t_abs, t_abs)
             dtime = t_abs - last_t_abs
+            viewzoom = tdw.scale
+            viewrotation = tdw.rotation
             self.stroke_to(
-                model, dtime, x, y, pressure, xtilt, ytilt,
+                model, dtime, x, y, pressure, xtilt, ytilt, viewzoom, viewrotation,
                 auto_split=False,
             )
             last_t_abs = t_abs
@@ -622,6 +632,8 @@ class InkingMode (gui.mode.ScrollableModeMixin,
             pressure=self._get_event_pressure(event),
             xtilt=xtilt, ytilt=ytilt,
             time=(event.time / 1000.0),
+            viewzoom = tdw.scale,
+            viewrotation = tdw.rotation,
         )
 
     def _get_event_pressure(self, event):

--- a/gui/inktool.py
+++ b/gui/inktool.py
@@ -42,7 +42,7 @@ class _Phase:
     ADJUST = 1
 
 
-_NODE_FIELDS = ("x", "y", "pressure", "xtilt", "ytilt", "time")
+_NODE_FIELDS = ("x", "y", "pressure", "xtilt", "ytilt", "time", "rotation")
 
 
 class _Node (collections.namedtuple("_Node", _NODE_FIELDS)):
@@ -54,6 +54,7 @@ class _Node (collections.namedtuple("_Node", _NODE_FIELDS)):
     * pressure: float in [0.0, 1.0]
     * xtilt, ytilt: float in [-1.0, 1.0]
     * time: absolute seconds, float
+    * rotation: float in [0.0, 1.0]
     """
 
 
@@ -151,6 +152,7 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         self._last_good_raw_pressure = 0.0
         self._last_good_raw_xtilt = 0.0
         self._last_good_raw_ytilt = 0.0
+        self._last_good_raw_rotation = 0.0
 
     def _reset_nodes(self):
         self.nodes = []  # nodes that met the distance+time criteria
@@ -282,6 +284,7 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         self._last_good_raw_pressure = 0.0
         self._last_good_raw_xtilt = 0.0
         self._last_good_raw_ytilt = 0.0
+        self._last_good_raw_rotation = 0.0
         # Supercall: start drags etc
         return super(InkingMode, self).button_press_cb(tdw, event)
 
@@ -317,6 +320,7 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         self._last_good_raw_pressure = 0.0
         self._last_good_raw_xtilt = 0.0
         self._last_good_raw_ytilt = 0.0
+        self._last_good_raw_rotation = 0.0
         # Supercall: stop current drag
         return super(InkingMode, self).button_release_cb(tdw, event)
 
@@ -651,10 +655,15 @@ class InkingMode (gui.mode.ScrollableModeMixin,
                 self._last_good_raw_pressure = pressure
         return pressure
 
+	#If WHEEL is missing (rotation)
+	if rotation is None:
+            rotation = 0.0
+
     def _get_event_tilt(self, tdw, event):
         # FIXME: CODE DUPLICATION: copied from freehand.py
         xtilt = event.get_axis(Gdk.AxisUse.XTILT)
         ytilt = event.get_axis(Gdk.AxisUse.YTILT)
+	rotation = event.get_axis(Gdk.AxisUse.WHEEL)
         if xtilt is None or ytilt is None or not np.isfinite(xtilt + ytilt):
             return (0.0, 0.0)
 

--- a/gui/inktool.py
+++ b/gui/inktool.py
@@ -42,7 +42,7 @@ class _Phase:
     ADJUST = 1
 
 
-_NODE_FIELDS = ("x", "y", "pressure", "xtilt", "ytilt", "time", "rotation")
+_NODE_FIELDS = ("x", "y", "pressure", "xtilt", "ytilt", "time")
 
 
 class _Node (collections.namedtuple("_Node", _NODE_FIELDS)):
@@ -54,7 +54,6 @@ class _Node (collections.namedtuple("_Node", _NODE_FIELDS)):
     * pressure: float in [0.0, 1.0]
     * xtilt, ytilt: float in [-1.0, 1.0]
     * time: absolute seconds, float
-    * rotation: float in [0.0, 1.0]
     """
 
 
@@ -152,7 +151,6 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         self._last_good_raw_pressure = 0.0
         self._last_good_raw_xtilt = 0.0
         self._last_good_raw_ytilt = 0.0
-        self._last_good_raw_rotation = 0.0
 
     def _reset_nodes(self):
         self.nodes = []  # nodes that met the distance+time criteria
@@ -284,7 +282,6 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         self._last_good_raw_pressure = 0.0
         self._last_good_raw_xtilt = 0.0
         self._last_good_raw_ytilt = 0.0
-        self._last_good_raw_rotation = 0.0
         # Supercall: start drags etc
         return super(InkingMode, self).button_press_cb(tdw, event)
 
@@ -320,7 +317,6 @@ class InkingMode (gui.mode.ScrollableModeMixin,
         self._last_good_raw_pressure = 0.0
         self._last_good_raw_xtilt = 0.0
         self._last_good_raw_ytilt = 0.0
-        self._last_good_raw_rotation = 0.0
         # Supercall: stop current drag
         return super(InkingMode, self).button_release_cb(tdw, event)
 
@@ -655,15 +651,10 @@ class InkingMode (gui.mode.ScrollableModeMixin,
                 self._last_good_raw_pressure = pressure
         return pressure
 
-	#If WHEEL is missing (rotation)
-	if rotation is None:
-            rotation = 0.0
-
     def _get_event_tilt(self, tdw, event):
         # FIXME: CODE DUPLICATION: copied from freehand.py
         xtilt = event.get_axis(Gdk.AxisUse.XTILT)
         ytilt = event.get_axis(Gdk.AxisUse.YTILT)
-	rotation = event.get_axis(Gdk.AxisUse.WHEEL)
         if xtilt is None or ytilt is None or not np.isfinite(xtilt + ytilt):
             return (0.0, 0.0)
 

--- a/gui/inktool.py
+++ b/gui/inktool.py
@@ -490,8 +490,8 @@ class InkingMode (gui.mode.ScrollableModeMixin,
             ytilt = lib.helpers.clamp(ytilt, -1.0, 1.0)
             t_abs = max(last_t_abs, t_abs)
             dtime = t_abs - last_t_abs
-            viewzoom = tdw.scale
-            viewrotation = tdw.rotation
+            viewzoom = self.doc.tdw.rotation
+            viewrotation = self.doc.tdw.rotation
             self.stroke_to(
                 model, dtime, x, y, pressure, xtilt, ytilt, viewzoom, viewrotation,
                 auto_split=False,
@@ -632,8 +632,8 @@ class InkingMode (gui.mode.ScrollableModeMixin,
             pressure=self._get_event_pressure(event),
             xtilt=xtilt, ytilt=ytilt,
             time=(event.time / 1000.0),
-            viewzoom = tdw.scale,
-            viewrotation = tdw.rotation,
+            viewzoom = self.doc.tdw.scale,
+            viewrotation = self.doc.tdw.rotation,
         )
 
     def _get_event_pressure(self, event):

--- a/gui/inputtestwindow.py
+++ b/gui/inputtestwindow.py
@@ -149,6 +149,10 @@ class InputTestWindow (windowing.SubWindow):
         if has_xtilt and has_ytilt:
             self.tilt_label.set_text('%+4.4f / %+4.4f' % (xtilt, ytilt))
 
+        has_rotation, rotation = event.get_axis(Gdk.AxisUse.WHEEL)
+        if has_rotation:
+            self.rotation_label.set_text('%+4.4f' % (rotation))
+
         if widget is not self.app.doc.tdw:
             if widget is self.app.drawWindow:
                 msg += ' [drawWindow]'

--- a/gui/inputtestwindow.py
+++ b/gui/inputtestwindow.py
@@ -149,10 +149,6 @@ class InputTestWindow (windowing.SubWindow):
         if has_xtilt and has_ytilt:
             self.tilt_label.set_text('%+4.4f / %+4.4f' % (xtilt, ytilt))
 
-        has_rotation, rotation = event.get_axis(Gdk.AxisUse.WHEEL)
-        if has_rotation:
-            self.rotation_label.set_text('%+4.4f' % (rotation))
-
         if widget is not self.app.doc.tdw:
             if widget is self.app.drawWindow:
                 msg += ' [drawWindow]'

--- a/gui/linemode.py
+++ b/gui/linemode.py
@@ -645,16 +645,16 @@ class LineModeBase (gui.mode.ScrollableModeMixin,
             pressure = abs((i-tail)/tail_length * prange2 + midpoint_p)
             self._stroke_to(px, py, pressure)
 
-    def _stroke_to(self, x, y, pressure, viewzoom, viewrotation):
+    def _stroke_to(self, x, y, pressure):
         duration = 0.001
-        self.stroke_to(self.model, duration, x, y, pressure, 0.0, 0.0, viewzoom, viewrotation,
+        self.stroke_to(self.model, duration, x, y, pressure, 0.0, 0.0, self.doc.tdw.scale, self.doc.tdw.rotation,
                        auto_split=False)
 
     def brush_prep(self, sx, sy):
         # Send brush to where the stroke will begin
         self.model.brush.reset()
         self.brushwork_rollback(self.model)
-        self.stroke_to(self.model, 10.0, sx, sy, 0.0, 0.0, 0.0, viewzoom, viewrotation,
+        self.stroke_to(self.model, 10.0, sx, sy, 0.0, 0.0, 0.0, self.doc.tdw.scale, self.doc.tdw.rotation,
                        auto_split=False)
 
     ## Line mode settings

--- a/gui/linemode.py
+++ b/gui/linemode.py
@@ -645,16 +645,16 @@ class LineModeBase (gui.mode.ScrollableModeMixin,
             pressure = abs((i-tail)/tail_length * prange2 + midpoint_p)
             self._stroke_to(px, py, pressure)
 
-    def _stroke_to(self, x, y, pressure):
+    def _stroke_to(self, x, y, pressure, viewzoom, viewrotation):
         duration = 0.001
-        self.stroke_to(self.model, duration, x, y, pressure, 0.0, 0.0,
+        self.stroke_to(self.model, duration, x, y, pressure, 0.0, 0.0, viewzoom, viewrotation,
                        auto_split=False)
 
     def brush_prep(self, sx, sy):
         # Send brush to where the stroke will begin
         self.model.brush.reset()
         self.brushwork_rollback(self.model)
-        self.stroke_to(self.model, 10.0, sx, sy, 0.0, 0.0, 0.0,
+        self.stroke_to(self.model, 10.0, sx, sy, 0.0, 0.0, 0.0, viewzoom, viewrotation,
                        auto_split=False)
 
     ## Line mode settings

--- a/gui/mode.py
+++ b/gui/mode.py
@@ -705,10 +705,12 @@ class BrushworkModeMixin (InteractionMode):
         if cmd is None:
             return
         if abrupt and cmd.__last_pos is not None:
-            x, y, xtilt, ytilt = cmd.__last_pos
+            x, y, xtilt, ytilt, viewzoom, viewrotation = cmd.__last_pos
             pressure = 0.0
             dtime = 0.0
-            cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt)
+            viewzoom = tdw.scale
+            viewrotation = tdw.rotation
+            cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt, viewzoom, viewrotation)
         changed = cmd.stop_recording(revert=False)
         if changed:
             model.do(cmd)
@@ -740,7 +742,7 @@ class BrushworkModeMixin (InteractionMode):
         for model in list(self.__active_brushwork.keys()):
             self.brushwork_rollback(model)
 
-    def stroke_to(self, model, dtime, x, y, pressure, xtilt, ytilt,
+    def stroke_to(self, model, dtime, x, y, pressure, xtilt, ytilt, viewzoom, viewrotation,
                   auto_split=True):
         """Feeds an updated stroke position to the brush engine
 
@@ -768,8 +770,8 @@ class BrushworkModeMixin (InteractionMode):
         if not cmd:
             self.brushwork_begin(model, description=desc0, abrupt=False)
             cmd = self.__active_brushwork[model]
-        cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt)
-        cmd.__last_pos = (x, y, xtilt, ytilt)
+        cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt, viewzoom, viewrotation)
+        cmd.__last_pos = (x, y, xtilt, ytilt, viewzoom, viewrotation)
 
     def leave(self, **kwds):
         """Leave mode, committing outstanding brushwork as necessary

--- a/gui/mode.py
+++ b/gui/mode.py
@@ -708,8 +708,8 @@ class BrushworkModeMixin (InteractionMode):
             x, y, xtilt, ytilt, viewzoom, viewrotation = cmd.__last_pos
             pressure = 0.0
             dtime = 0.0
-            viewzoom = tdw.scale
-            viewrotation = tdw.rotation
+            viewzoom = self.doc.tdw.scale
+            viewrotation = self.doc.tdw.rotation
             cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt, viewzoom, viewrotation)
         changed = cmd.stop_recording(revert=False)
         if changed:

--- a/gui/mode.py
+++ b/gui/mode.py
@@ -708,7 +708,7 @@ class BrushworkModeMixin (InteractionMode):
             x, y, xtilt, ytilt = cmd.__last_pos
             pressure = 0.0
             dtime = 0.0
-            cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt)
+            cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt, rotation)
         changed = cmd.stop_recording(revert=False)
         if changed:
             model.do(cmd)
@@ -740,7 +740,7 @@ class BrushworkModeMixin (InteractionMode):
         for model in list(self.__active_brushwork.keys()):
             self.brushwork_rollback(model)
 
-    def stroke_to(self, model, dtime, x, y, pressure, xtilt, ytilt,
+    def stroke_to(self, model, dtime, x, y, pressure, xtilt, ytilt, rotation,
                   auto_split=True):
         """Feeds an updated stroke position to the brush engine
 
@@ -751,6 +751,7 @@ class BrushworkModeMixin (InteractionMode):
         :param float pressure: Pressure, ranging from 0.0 to 1.0
         :param float xtilt: X-axis tilt, ranging from -1.0 to 1.0
         :param float ytilt: Y-axis tilt, ranging from -1.0 to 1.0
+        :param float rotation: Stylus ranging from -900 to 900
         :param bool auto_split: Split ongoing brushwork if due
 
         During normal operation, succesive calls to `stroke_to()` record
@@ -768,8 +769,8 @@ class BrushworkModeMixin (InteractionMode):
         if not cmd:
             self.brushwork_begin(model, description=desc0, abrupt=False)
             cmd = self.__active_brushwork[model]
-        cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt)
-        cmd.__last_pos = (x, y, xtilt, ytilt)
+        cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt, rotation)
+        cmd.__last_pos = (x, y, xtilt, ytilt, rotation)
 
     def leave(self, **kwds):
         """Leave mode, committing outstanding brushwork as necessary

--- a/gui/mode.py
+++ b/gui/mode.py
@@ -708,7 +708,7 @@ class BrushworkModeMixin (InteractionMode):
             x, y, xtilt, ytilt = cmd.__last_pos
             pressure = 0.0
             dtime = 0.0
-            cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt, rotation)
+            cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt)
         changed = cmd.stop_recording(revert=False)
         if changed:
             model.do(cmd)
@@ -740,7 +740,7 @@ class BrushworkModeMixin (InteractionMode):
         for model in list(self.__active_brushwork.keys()):
             self.brushwork_rollback(model)
 
-    def stroke_to(self, model, dtime, x, y, pressure, xtilt, ytilt, rotation,
+    def stroke_to(self, model, dtime, x, y, pressure, xtilt, ytilt,
                   auto_split=True):
         """Feeds an updated stroke position to the brush engine
 
@@ -751,7 +751,6 @@ class BrushworkModeMixin (InteractionMode):
         :param float pressure: Pressure, ranging from 0.0 to 1.0
         :param float xtilt: X-axis tilt, ranging from -1.0 to 1.0
         :param float ytilt: Y-axis tilt, ranging from -1.0 to 1.0
-        :param float rotation: Stylus ranging from -900 to 900
         :param bool auto_split: Split ongoing brushwork if due
 
         During normal operation, succesive calls to `stroke_to()` record
@@ -769,8 +768,8 @@ class BrushworkModeMixin (InteractionMode):
         if not cmd:
             self.brushwork_begin(model, description=desc0, abrupt=False)
             cmd = self.__active_brushwork[model]
-        cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt, rotation)
-        cmd.__last_pos = (x, y, xtilt, ytilt, rotation)
+        cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt)
+        cmd.__last_pos = (x, y, xtilt, ytilt)
 
     def leave(self, **kwds):
         """Leave mode, committing outstanding brushwork as necessary

--- a/lib/brush.hpp
+++ b/lib/brush.hpp
@@ -62,10 +62,10 @@ public:
       mypaint_brush_set_state(c_brush, (MyPaintBrushState)i, value);
   }
 
-  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime)
+  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime, float viewzoom, float viewrotation)
   {
       MyPaintSurface *c_surface = surface->get_surface_interface();
-      bool retval = mypaint_brush_stroke_to(c_brush, c_surface, x, y, pressure, xtilt, ytilt, dtime);
+      bool retval = mypaint_brush_stroke_to(c_brush, c_surface, x, y, pressure, xtilt, ytilt, dtime, viewzoom, viewrotation);
       return retval;
   }
 

--- a/lib/brush.hpp
+++ b/lib/brush.hpp
@@ -62,10 +62,10 @@ public:
       mypaint_brush_set_state(c_brush, (MyPaintBrushState)i, value);
   }
 
-  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime)
+  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime, float rotation)
   {
       MyPaintSurface *c_surface = surface->get_surface_interface();
-      bool retval = mypaint_brush_stroke_to(c_brush, c_surface, x, y, pressure, xtilt, ytilt, dtime);
+      bool retval = mypaint_brush_stroke_to(c_brush, c_surface, x, y, pressure, xtilt, ytilt, dtime, rotation);
       return retval;
   }
 

--- a/lib/brush.hpp
+++ b/lib/brush.hpp
@@ -62,10 +62,10 @@ public:
       mypaint_brush_set_state(c_brush, (MyPaintBrushState)i, value);
   }
 
-  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime, float rotation)
+  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime)
   {
       MyPaintSurface *c_surface = surface->get_surface_interface();
-      bool retval = mypaint_brush_stroke_to(c_brush, c_surface, x, y, pressure, xtilt, ytilt, dtime, rotation);
+      bool retval = mypaint_brush_stroke_to(c_brush, c_surface, x, y, pressure, xtilt, ytilt, dtime);
       return retval;
   }
 

--- a/lib/command.py
+++ b/lib/command.py
@@ -363,7 +363,7 @@ class Brushwork (Command):
         assert self._sshot_after is None
         self._recording_started = True
 
-    def stroke_to(self, dtime, x, y, pressure, xtilt, ytilt):
+    def stroke_to(self, dtime, x, y, pressure, xtilt, ytilt, viewzoom, viewrotation):
         """Painting: forward a stroke position update to the model
 
         :param float dtime: Seconds since the last call to this method
@@ -372,6 +372,8 @@ class Brushwork (Command):
         :param float pressure: Pressure, ranging from 0.0 to 1.0
         :param float xtilt: X-axis tilt, ranging from -1.0 to 1.0
         :param float ytilt: Y-axis tilt, ranging from -1.0 to 1.0
+        :param float viewzoom: current view zoom level from 0 to 64
+        :param float viewrotation; current view rotation from -180.0 to 180.0
 
         Stroke data is recorded at this level, but strokes are not
         autosplit here because that would involve the creation of a new
@@ -390,18 +392,18 @@ class Brushwork (Command):
         brush = model.brush
         if self._abrupt_start and not self._abrupt_start_done:
             brush.reset()
-            layer.stroke_to(brush, x, y, 0.0, xtilt, ytilt, 10.0)
+            layer.stroke_to(brush, x, y, 0.0, xtilt, ytilt, 10.0, viewzoom, viewrotation)
             self._abrupt_start_done = True
         # Record and paint this position
         self._stroke_seq.record_event(
             dtime,
             x, y, pressure,
-            xtilt, ytilt,
+            xtilt, ytilt, viewzoom, viewrotation,
         )
         self.split_due = layer.stroke_to(
             brush,
             x, y, pressure,
-            xtilt, ytilt, dtime,
+            xtilt, ytilt, dtime, viewzoom, viewrotation,
         )
 
     def stop_recording(self, revert=False):

--- a/lib/command.py
+++ b/lib/command.py
@@ -363,7 +363,7 @@ class Brushwork (Command):
         assert self._sshot_after is None
         self._recording_started = True
 
-    def stroke_to(self, dtime, x, y, pressure, xtilt, ytilt):
+    def stroke_to(self, dtime, x, y, pressure, xtilt, ytilt, rotation):
         """Painting: forward a stroke position update to the model
 
         :param float dtime: Seconds since the last call to this method
@@ -372,6 +372,7 @@ class Brushwork (Command):
         :param float pressure: Pressure, ranging from 0.0 to 1.0
         :param float xtilt: X-axis tilt, ranging from -1.0 to 1.0
         :param float ytilt: Y-axis tilt, ranging from -1.0 to 1.0
+        :param float rotation: Rotation of stylus, ranging from -900 to 900 
 
         Stroke data is recorded at this level, but strokes are not
         autosplit here because that would involve the creation of a new
@@ -390,18 +391,18 @@ class Brushwork (Command):
         brush = model.brush
         if self._abrupt_start and not self._abrupt_start_done:
             brush.reset()
-            layer.stroke_to(brush, x, y, 0.0, xtilt, ytilt, 10.0)
+            layer.stroke_to(brush, x, y, 0.0, xtilt, ytilt, 10.0, rotation)
             self._abrupt_start_done = True
         # Record and paint this position
         self._stroke_seq.record_event(
             dtime,
             x, y, pressure,
-            xtilt, ytilt,
+            xtilt, ytilt, rotation
         )
         self.split_due = layer.stroke_to(
             brush,
             x, y, pressure,
-            xtilt, ytilt, dtime,
+            xtilt, ytilt, dtime, rotation
         )
 
     def stop_recording(self, revert=False):

--- a/lib/command.py
+++ b/lib/command.py
@@ -363,7 +363,7 @@ class Brushwork (Command):
         assert self._sshot_after is None
         self._recording_started = True
 
-    def stroke_to(self, dtime, x, y, pressure, xtilt, ytilt, rotation):
+    def stroke_to(self, dtime, x, y, pressure, xtilt, ytilt):
         """Painting: forward a stroke position update to the model
 
         :param float dtime: Seconds since the last call to this method
@@ -372,7 +372,6 @@ class Brushwork (Command):
         :param float pressure: Pressure, ranging from 0.0 to 1.0
         :param float xtilt: X-axis tilt, ranging from -1.0 to 1.0
         :param float ytilt: Y-axis tilt, ranging from -1.0 to 1.0
-        :param float rotation: Rotation of stylus, ranging from -900 to 900 
 
         Stroke data is recorded at this level, but strokes are not
         autosplit here because that would involve the creation of a new
@@ -391,18 +390,18 @@ class Brushwork (Command):
         brush = model.brush
         if self._abrupt_start and not self._abrupt_start_done:
             brush.reset()
-            layer.stroke_to(brush, x, y, 0.0, xtilt, ytilt, 10.0, rotation)
+            layer.stroke_to(brush, x, y, 0.0, xtilt, ytilt, 10.0)
             self._abrupt_start_done = True
         # Record and paint this position
         self._stroke_seq.record_event(
             dtime,
             x, y, pressure,
-            xtilt, ytilt, rotation
+            xtilt, ytilt,
         )
         self.split_due = layer.stroke_to(
             brush,
             x, y, pressure,
-            xtilt, ytilt, dtime, rotation
+            xtilt, ytilt, dtime,
         )
 
     def stop_recording(self, revert=False):

--- a/lib/layer/data.py
+++ b/lib/layer/data.py
@@ -1343,7 +1343,7 @@ class PaintingLayer (SurfaceBackedLayer, core.ExternallyEditable):
 
     ## Painting
 
-    def stroke_to(self, brush, x, y, pressure, xtilt, ytilt, dtime):
+    def stroke_to(self, brush, x, y, pressure, xtilt, ytilt, dtime, rotation):
         """Render a part of a stroke to the canvas surface
 
         :param brush: The brush to use for rendering dabs
@@ -1354,6 +1354,7 @@ class PaintingLayer (SurfaceBackedLayer, core.ExternallyEditable):
         :param xtilt: Input event's tilt component in the document X direction
         :param ytilt: Input event's tilt component in the document Y direction
         :param dtime: Time delta, in seconds
+        :param rotation: Input event's rotation component
         :returns: whether the stroke should now be split
         :rtype: bool
 
@@ -1367,7 +1368,7 @@ class PaintingLayer (SurfaceBackedLayer, core.ExternallyEditable):
         self._surface.begin_atomic()
         split = brush.stroke_to(
             self._surface.backend, x, y,
-            pressure, xtilt, ytilt, dtime
+            pressure, xtilt, ytilt, dtime, rotation
         )
         self._surface.end_atomic()
         self.autosave_dirty = True

--- a/lib/layer/data.py
+++ b/lib/layer/data.py
@@ -1343,7 +1343,7 @@ class PaintingLayer (SurfaceBackedLayer, core.ExternallyEditable):
 
     ## Painting
 
-    def stroke_to(self, brush, x, y, pressure, xtilt, ytilt, dtime):
+    def stroke_to(self, brush, x, y, pressure, xtilt, ytilt, dtime, viewzoom, viewrotation):
         """Render a part of a stroke to the canvas surface
 
         :param brush: The brush to use for rendering dabs
@@ -1367,7 +1367,7 @@ class PaintingLayer (SurfaceBackedLayer, core.ExternallyEditable):
         self._surface.begin_atomic()
         split = brush.stroke_to(
             self._surface.backend, x, y,
-            pressure, xtilt, ytilt, dtime
+            pressure, xtilt, ytilt, dtime, viewzoom, viewrotation
         )
         self._surface.end_atomic()
         self.autosave_dirty = True

--- a/lib/layer/data.py
+++ b/lib/layer/data.py
@@ -1343,7 +1343,7 @@ class PaintingLayer (SurfaceBackedLayer, core.ExternallyEditable):
 
     ## Painting
 
-    def stroke_to(self, brush, x, y, pressure, xtilt, ytilt, dtime, rotation):
+    def stroke_to(self, brush, x, y, pressure, xtilt, ytilt, dtime):
         """Render a part of a stroke to the canvas surface
 
         :param brush: The brush to use for rendering dabs
@@ -1354,7 +1354,6 @@ class PaintingLayer (SurfaceBackedLayer, core.ExternallyEditable):
         :param xtilt: Input event's tilt component in the document X direction
         :param ytilt: Input event's tilt component in the document Y direction
         :param dtime: Time delta, in seconds
-        :param rotation: Input event's rotation component
         :returns: whether the stroke should now be split
         :rtype: bool
 
@@ -1368,7 +1367,7 @@ class PaintingLayer (SurfaceBackedLayer, core.ExternallyEditable):
         self._surface.begin_atomic()
         split = brush.stroke_to(
             self._surface.backend, x, y,
-            pressure, xtilt, ytilt, dtime, rotation
+            pressure, xtilt, ytilt, dtime
         )
         self._surface.end_atomic()
         self.autosave_dirty = True

--- a/lib/python_brush.hpp
+++ b/lib/python_brush.hpp
@@ -47,9 +47,9 @@ public:
   // Same as Brush::stroke_to() but with minimal exception handling:
   // don't indicate that a split is pending should an exception happen
   // in the surface code (e.g. out-of-memory)
-  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime)
+  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime, float viewzoom, float viewrotation)
   {
-    bool res = Brush::stroke_to (surface, x, y, pressure, xtilt, ytilt, dtime);
+    bool res = Brush::stroke_to (surface, x, y, pressure, xtilt, ytilt, dtime, viewzoom, viewrotation);
     if (PyErr_Occurred()) {
       res = false;
     }

--- a/lib/python_brush.hpp
+++ b/lib/python_brush.hpp
@@ -47,9 +47,9 @@ public:
   // Same as Brush::stroke_to() but with minimal exception handling:
   // don't indicate that a split is pending should an exception happen
   // in the surface code (e.g. out-of-memory)
-  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime, float rotation)
+  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime)
   {
-    bool res = Brush::stroke_to (surface, x, y, pressure, xtilt, ytilt, dtime, rotation);
+    bool res = Brush::stroke_to (surface, x, y, pressure, xtilt, ytilt, dtime);
     if (PyErr_Occurred()) {
       res = false;
     }

--- a/lib/python_brush.hpp
+++ b/lib/python_brush.hpp
@@ -47,9 +47,9 @@ public:
   // Same as Brush::stroke_to() but with minimal exception handling:
   // don't indicate that a split is pending should an exception happen
   // in the surface code (e.g. out-of-memory)
-  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime)
+  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime, float rotation)
   {
-    bool res = Brush::stroke_to (surface, x, y, pressure, xtilt, ytilt, dtime);
+    bool res = Brush::stroke_to (surface, x, y, pressure, xtilt, ytilt, dtime, rotation);
     if (PyErr_Occurred()) {
       res = false;
     }

--- a/lib/stroke.py
+++ b/lib/stroke.py
@@ -49,9 +49,9 @@ class Stroke (object):
 
         self.tmp_event_list = []
 
-    def record_event(self, dtime, x, y, pressure, xtilt, ytilt, rotation):
+    def record_event(self, dtime, x, y, pressure, xtilt, ytilt):
         assert not self.finished
-        self.tmp_event_list.append((dtime, x, y, pressure, xtilt, ytilt, rotation))
+        self.tmp_event_list.append((dtime, x, y, pressure, xtilt, ytilt))
 
     def stop_recording(self):
         if self.finished:
@@ -94,8 +94,8 @@ class Stroke (object):
         data.shape = (len(data)/6, 6)
 
         surface.begin_atomic()
-        for dtime, x, y, pressure, xtilt, ytilt, rotation in data:
-            b.stroke_to(surface.backend, x, y, pressure, xtilt, ytilt, dtime, rotation)
+        for dtime, x, y, pressure, xtilt, ytilt in data:
+            b.stroke_to(surface.backend, x, y, pressure, xtilt, ytilt, dtime)
         surface.end_atomic()
 
     def copy_using_different_brush(self, brushinfo):

--- a/lib/stroke.py
+++ b/lib/stroke.py
@@ -49,9 +49,9 @@ class Stroke (object):
 
         self.tmp_event_list = []
 
-    def record_event(self, dtime, x, y, pressure, xtilt, ytilt):
+    def record_event(self, dtime, x, y, pressure, xtilt, ytilt, rotation):
         assert not self.finished
-        self.tmp_event_list.append((dtime, x, y, pressure, xtilt, ytilt))
+        self.tmp_event_list.append((dtime, x, y, pressure, xtilt, ytilt, rotation))
 
     def stop_recording(self):
         if self.finished:
@@ -94,8 +94,8 @@ class Stroke (object):
         data.shape = (len(data)/6, 6)
 
         surface.begin_atomic()
-        for dtime, x, y, pressure, xtilt, ytilt in data:
-            b.stroke_to(surface.backend, x, y, pressure, xtilt, ytilt, dtime)
+        for dtime, x, y, pressure, xtilt, ytilt, rotation in data:
+            b.stroke_to(surface.backend, x, y, pressure, xtilt, ytilt, dtime, rotation)
         surface.end_atomic()
 
     def copy_using_different_brush(self, brushinfo):

--- a/lib/stroke.py
+++ b/lib/stroke.py
@@ -49,9 +49,9 @@ class Stroke (object):
 
         self.tmp_event_list = []
 
-    def record_event(self, dtime, x, y, pressure, xtilt, ytilt):
+    def record_event(self, dtime, x, y, pressure, xtilt, ytilt, viewzoom, viewrotation):
         assert not self.finished
-        self.tmp_event_list.append((dtime, x, y, pressure, xtilt, ytilt))
+        self.tmp_event_list.append((dtime, x, y, pressure, xtilt, ytilt, viewzoom, viewrotation))
 
     def stop_recording(self):
         if self.finished:
@@ -91,11 +91,11 @@ class Stroke (object):
         version, data = self.stroke_data[0], self.stroke_data[1:]
         assert version == '2'
         data = np.fromstring(data, dtype='float64')
-        data.shape = (len(data)/6, 6)
+        data.shape = (len(data)/8, 8)
 
         surface.begin_atomic()
-        for dtime, x, y, pressure, xtilt, ytilt in data:
-            b.stroke_to(surface.backend, x, y, pressure, xtilt, ytilt, dtime)
+        for dtime, x, y, pressure, xtilt, ytilt, viewzoom, viewrotation in data:
+            b.stroke_to(surface.backend, x, y, pressure, xtilt, ytilt, dtime, viewzoom, viewrotation)
         surface.end_atomic()
 
     def copy_using_different_brush(self, brushinfo):


### PR DESCRIPTION
This is related to 
https://github.com/mypaint/libmypaint/pull/70
This adds viewzoom and viewrotation as inputs to libmypaint so the brush engine can make corrections to inputs to account for zoom level and canvas rotation.  Additional changes to the gui might be needed.

I just noticed the early commits have mention of pen-rotation-- this pull does not include pen-rotation.  I'm still learning git I must have goofed something there.