### PR TITLE
Try to get libmypaint from the same prefix as the CI clone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ build:
   shell: mingw$$arch
   commands:
     - env
+    - git config --get remote.origin.url
     - windows/msys2-build.sh installdeps
     - windows/msys2-build.sh build
     - windows/msys2-build.sh test

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ build:
 
 matrix:
   arch:
-    - 64
+    - 32
 
 # Currently broken, again
-#   - 32
+#   - 64

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,7 @@ build:
   pull: true
   shell: mingw$$arch
   commands:
+    - env
     - windows/msys2-build.sh installdeps
     - windows/msys2-build.sh build
     - windows/msys2-build.sh test

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,6 @@ build:
   shell: mingw$$arch
   commands:
     - env
-    - git config --get remote.origin.url
     - windows/msys2-build.sh installdeps
     - windows/msys2-build.sh build
     - windows/msys2-build.sh test
@@ -16,4 +15,6 @@ build:
 matrix:
   arch:
     - 64
-    - 32
+
+# Currently broken, again
+#   - 32

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
       - git
 
 before_script:
+    - env
     - git clone https://github.com/mypaint/libmypaint
     - cd libmypaint
     - ./autogen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ addons:
 
 before_script:
     - env
+    - git config --get remote.origin.url
     - git clone https://github.com/mypaint/libmypaint
     - cd libmypaint
     - ./autogen.sh


### PR DESCRIPTION
For CI, MyPaint should try to obtain and build libmypaint from the same URI prefix as the mypaint branch+remote it's currently building. See mypaint/mypaint#784.

This branch is going to be **highly volatile** for a bit, until I've settled on a solution :flushed: 
I'll merge it when/if it becomes ready.