### PR TITLE
inputs: add barrel-rotation support (Art Pen, etc)

### DIFF
--- a/gui/drawutils.py
+++ b/gui/drawutils.py
@@ -40,14 +40,14 @@ from lib.pixbufsurface import render_as_pixbuf
 ## Module constants
 
 _BRUSH_PREVIEW_POINTS = [
-    # px,  py,   press, xtilt, ytilt  # px,  py,   press, xtilt, ytilt
-    (0.00, 0.00,  0.00,  0.00, 0.00), (1.00, 0.05,  0.00, -0.06, 0.05),
-    (0.10, 0.10,  0.20,  0.10, 0.05), (0.90, 0.15,  0.90, -0.05, 0.05),
-    (0.11, 0.30,  0.90,  0.08, 0.05), (0.86, 0.35,  0.90, -0.04, 0.05),
-    (0.13, 0.50,  0.90,  0.06, 0.05), (0.84, 0.55,  0.90, -0.03, 0.05),
-    (0.17, 0.70,  0.90,  0.04, 0.05), (0.83, 0.75,  0.90, -0.02, 0.05),
-    (0.25, 0.90,  0.20,  0.02, 0.00), (0.81, 0.95,  0.00,  0.00, 0.00),
-    (0.41, 0.95,  0.00,  0.00, 0.00), (0.80, 1.00,  0.00,  0.00, 0.00),
+    # px,  py,   press, xtilt, ytilt, barrel_rotation  # px,  py,   press, xtilt, ytilt, barrel_rotation
+    (0.00, 0.00,  0.00,  0.00, 0.00, 0.00), (1.00, 0.05,  0.00, -0.06, 0.05, 0.00),
+    (0.10, 0.10,  0.20,  0.10, 0.05, 0.00), (0.90, 0.15,  0.90, -0.05, 0.05, 0.00),
+    (0.11, 0.30,  0.90,  0.08, 0.05, 0.00), (0.86, 0.35,  0.90, -0.04, 0.05, 0.00),
+    (0.13, 0.50,  0.90,  0.06, 0.05, 0.00), (0.84, 0.55,  0.90, -0.03, 0.05, 0.00),
+    (0.17, 0.70,  0.90,  0.04, 0.05, 0.00), (0.83, 0.75,  0.90, -0.02, 0.05, 0.00),
+    (0.25, 0.90,  0.20,  0.02, 0.00, 0.00), (0.81, 0.95,  0.00,  0.00, 0.00, 0.00),
+    (0.41, 0.95,  0.00,  0.00, 0.00, 0.00), (0.80, 1.00,  0.00,  0.00, 0.00, 0.00),
 ]
 
 
@@ -113,19 +113,19 @@ def spline_iter(tuples, double_first=True, double_last=True):
 
 def _variable_pressure_scribble(w, h, tmult):
     points = _BRUSH_PREVIEW_POINTS
-    px, py, press, xtilt, ytilt = points[0]
-    yield (10, px*w, py*h, 0.0, xtilt, ytilt)
+    px, py, press, xtilt, ytilt, barrel_rotation = points[0]
+    yield (10, px*w, py*h, 0.0, xtilt, ytilt, barrel_rotation)
     event_dtime = 0.005
     point_time = 0.1
-    for p_1, p0, p1, p2 in spline_iter(points, True, True):
+    for p_1, p0, p1, p2, p3 in spline_iter(points, True, True):
         dt = 0.0
         while dt < point_time:
             t = dt/point_time
-            px, py, press, xtilt, ytilt = spline_4p(t, p_1, p0, p1, p2)
-            yield (event_dtime, px*w, py*h, press, xtilt, ytilt)
+            px, py, press, xtilt, ytilt, barrel_rotation = spline_4p(t, p_1, p0, p1, p2, p3)
+            yield (event_dtime, px*w, py*h, press, xtilt, ytilt, barrel_rotation)
             dt += event_dtime
-    px, py, press, xtilt, ytilt = points[-1]
-    yield (10, px*w, py*h, 0.0, xtilt, ytilt)
+    px, py, press, xtilt, ytilt, barrel_rotation = points[-1]
+    yield (10, px*w, py*h, 0.0, xtilt, ytilt, barrel_rotation)
 
 
 def render_brush_preview_pixbuf(brushinfo, max_edge_tiles=4):
@@ -161,8 +161,8 @@ def render_brush_preview_pixbuf(brushinfo, max_edge_tiles=4):
         # Curve
         shape = _variable_pressure_scribble(width, height, size_in_tiles)
         surface.begin_atomic()
-        for dt, x, y, p, xt, yt in shape:
-            brush.stroke_to(surface.backend, x, y, p, xt, yt, dt)
+        for dt, x, y, p, xt, yt, br in shape:
+            brush.stroke_to(surface.backend, x, y, p, xt, yt, dt, br)
         surface.end_atomic()
         # Check rendered size
         tposs = surface.tiledict.keys()

--- a/gui/inputtestwindow.py
+++ b/gui/inputtestwindow.py
@@ -71,6 +71,9 @@ class InputTestWindow (windowing.SubWindow):
         l = self.device_label = Gtk.Label(_('(no device)'))
         add(3, _('Device:'), l)
 
+        l = self.barrel_rotation_label = Gtk.Label(_('(No Barrel Rotation)'))
+        add(4, _('Barrel Rotation:'), l)
+
         vbox.pack_start(Gtk.HSeparator(), False, False, 0)
 
         tv = self.tv = Gtk.TextView()
@@ -148,6 +151,10 @@ class InputTestWindow (windowing.SubWindow):
         has_ytilt, ytilt = event.get_axis(Gdk.AxisUse.YTILT)
         if has_xtilt and has_ytilt:
             self.tilt_label.set_text('%+4.4f / %+4.4f' % (xtilt, ytilt))
+
+        has_barrel_rotation, barrel_rotation = event.get_axis(Gdk.AxisUse.WHEEL)
+        if has_barrel_rotation:
+            self.barrel_rotation_label.set_text('%+4.4f' % (barrel_rotation))
 
         if widget is not self.app.doc.tdw:
             if widget is self.app.drawWindow:

--- a/gui/linemode.py
+++ b/gui/linemode.py
@@ -647,14 +647,14 @@ class LineModeBase (gui.mode.ScrollableModeMixin,
 
     def _stroke_to(self, x, y, pressure):
         duration = 0.001
-        self.stroke_to(self.model, duration, x, y, pressure, 0.0, 0.0,
+        self.stroke_to(self.model, duration, x, y, pressure, 0.0, 0.0, 0.0,
                        auto_split=False)
 
     def brush_prep(self, sx, sy):
         # Send brush to where the stroke will begin
         self.model.brush.reset()
         self.brushwork_rollback(self.model)
-        self.stroke_to(self.model, 10.0, sx, sy, 0.0, 0.0, 0.0,
+        self.stroke_to(self.model, 10.0, sx, sy, 0.0, 0.0, 0.0, 0.0,
                        auto_split=False)
 
     ## Line mode settings

--- a/gui/mode.py
+++ b/gui/mode.py
@@ -727,10 +727,11 @@ class BrushworkModeMixin (InteractionMode):
         if cmd is None:
             return
         if abrupt and cmd.__last_pos is not None:
-            x, y, xtilt, ytilt = cmd.__last_pos
+            x, y, xtilt, ytilt, barrel_rotation = cmd.__last_pos
             pressure = 0.0
             dtime = 0.0
-            cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt)
+            barrel_rotation = 0.0
+            cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt, barrel_rotation)
         changed = cmd.stop_recording(revert=False)
         if changed:
             model.do(cmd)
@@ -762,7 +763,7 @@ class BrushworkModeMixin (InteractionMode):
         for model in list(self.__active_brushwork.keys()):
             self.brushwork_rollback(model)
 
-    def stroke_to(self, model, dtime, x, y, pressure, xtilt, ytilt,
+    def stroke_to(self, model, dtime, x, y, pressure, xtilt, ytilt, barrel_rotation,
                   auto_split=True, layer=None):
         """Feeds an updated stroke position to the brush engine
 
@@ -773,6 +774,7 @@ class BrushworkModeMixin (InteractionMode):
         :param float pressure: Pressure, ranging from 0.0 to 1.0
         :param float xtilt: X-axis tilt, ranging from -1.0 to 1.0
         :param float ytilt: Y-axis tilt, ranging from -1.0 to 1.0
+        :param float barrel_rotation: Stylus barrel rotation ranging from 0.0 to 1.0
         :param bool auto_split: Split ongoing brushwork if due
         :param gui.layer.data.SimplePaintingLayer layer: explicit target layer
 
@@ -803,8 +805,8 @@ class BrushworkModeMixin (InteractionMode):
                 layer=layer,
             )
             cmd = self.__active_brushwork[model]
-        cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt)
-        cmd.__last_pos = (x, y, xtilt, ytilt)
+        cmd.stroke_to(dtime, x, y, pressure, xtilt, ytilt, barrel_rotation)
+        cmd.__last_pos = (x, y, xtilt, ytilt, barrel_rotation)
 
     def leave(self, **kwds):
         """Leave mode, committing outstanding brushwork as necessary

--- a/lib/brush.hpp
+++ b/lib/brush.hpp
@@ -62,10 +62,10 @@ public:
       mypaint_brush_set_state(c_brush, (MyPaintBrushState)i, value);
   }
 
-  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime)
+  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime, float barrel_rotation)
   {
       MyPaintSurface *c_surface = surface->get_surface_interface();
-      bool retval = mypaint_brush_stroke_to(c_brush, c_surface, x, y, pressure, xtilt, ytilt, dtime);
+      bool retval = mypaint_brush_stroke_to(c_brush, c_surface, x, y, pressure, xtilt, ytilt, dtime, barrel_rotation);
       return retval;
   }
 

--- a/lib/command.py
+++ b/lib/command.py
@@ -389,7 +389,7 @@ class Brushwork (Command):
         assert self._sshot_after is None
         self._recording_started = True
 
-    def stroke_to(self, dtime, x, y, pressure, xtilt, ytilt):
+    def stroke_to(self, dtime, x, y, pressure, xtilt, ytilt, barrel_rotation):
         """Painting: forward a stroke position update to the model
 
         :param float dtime: Seconds since the last call to this method
@@ -398,6 +398,7 @@ class Brushwork (Command):
         :param float pressure: Pressure, ranging from 0.0 to 1.0
         :param float xtilt: X-axis tilt, ranging from -1.0 to 1.0
         :param float ytilt: Y-axis tilt, ranging from -1.0 to 1.0
+        :param float barrel_rotation: Barrel Rotation of stylus, ranging from 0.0 to 1.0 
 
         Stroke data is recorded at this level, but strokes are not
         autosplit here because that would involve the creation of a new
@@ -416,18 +417,18 @@ class Brushwork (Command):
         brush = model.brush
         if self._abrupt_start and not self._abrupt_start_done:
             brush.reset()
-            layer.stroke_to(brush, x, y, 0.0, xtilt, ytilt, 10.0)
+            layer.stroke_to(brush, x, y, 0.0, xtilt, ytilt, 10.0, barrel_rotation)
             self._abrupt_start_done = True
         # Record and paint this position
         self._stroke_seq.record_event(
             dtime,
             x, y, pressure,
-            xtilt, ytilt,
+            xtilt, ytilt, barrel_rotation
         )
         self.split_due = layer.stroke_to(
             brush,
             x, y, pressure,
-            xtilt, ytilt, dtime,
+            xtilt, ytilt, dtime, barrel_rotation
         )
 
     def stop_recording(self, revert=False):

--- a/lib/layer/data.py
+++ b/lib/layer/data.py
@@ -1285,7 +1285,7 @@ class SimplePaintingLayer (SurfaceBackedLayer):
             and not self.branch_locked
         )
 
-    def stroke_to(self, brush, x, y, pressure, xtilt, ytilt, dtime):
+    def stroke_to(self, brush, x, y, pressure, xtilt, ytilt, dtime, barrel_rotation):
         """Render a part of a stroke to the canvas surface
 
         :param brush: The brush to use for rendering dabs
@@ -1315,7 +1315,7 @@ class SimplePaintingLayer (SurfaceBackedLayer):
         self._surface.begin_atomic()
         split = brush.stroke_to(
             self._surface.backend, x, y,
-            pressure, xtilt, ytilt, dtime
+            pressure, xtilt, ytilt, dtime, barrel_rotation
         )
         self._surface.end_atomic()
         self.autosave_dirty = True

--- a/lib/python_brush.hpp
+++ b/lib/python_brush.hpp
@@ -47,9 +47,9 @@ public:
   // Same as Brush::stroke_to() but with minimal exception handling:
   // don't indicate that a split is pending should an exception happen
   // in the surface code (e.g. out-of-memory)
-  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime)
+  bool stroke_to (Surface * surface, float x, float y, float pressure, float xtilt, float ytilt, double dtime, float barrel_rotation)
   {
-    bool res = Brush::stroke_to (surface, x, y, pressure, xtilt, ytilt, dtime);
+    bool res = Brush::stroke_to (surface, x, y, pressure, xtilt, ytilt, dtime, barrel_rotation);
     if (PyErr_Occurred()) {
       res = false;
     }

--- a/lib/stroke.py
+++ b/lib/stroke.py
@@ -49,9 +49,9 @@ class Stroke (object):
 
         self.tmp_event_list = []
 
-    def record_event(self, dtime, x, y, pressure, xtilt, ytilt):
+    def record_event(self, dtime, x, y, pressure, xtilt, ytilt, barrel_rotation):
         assert not self.finished
-        self.tmp_event_list.append((dtime, x, y, pressure, xtilt, ytilt))
+        self.tmp_event_list.append((dtime, x, y, pressure, xtilt, ytilt, barrel_rotation))
 
     def stop_recording(self):
         if self.finished:
@@ -91,11 +91,11 @@ class Stroke (object):
         version, data = self.stroke_data[0], self.stroke_data[1:]
         assert version == '2'
         data = np.fromstring(data, dtype='float64')
-        data.shape = (len(data) // 6, 6)
+        data.shape = (len(data) // 7, 7)
 
         surface.begin_atomic()
-        for dtime, x, y, pressure, xtilt, ytilt in data:
-            b.stroke_to(surface.backend, x, y, pressure, xtilt, ytilt, dtime)
+        for dtime, x, y, pressure, xtilt, ytilt, barrel_rotation in data:
+            b.stroke_to(surface.backend, x, y, pressure, xtilt, ytilt, dtime, barrel_rotation)
         surface.end_atomic()
 
     def copy_using_different_brush(self, brushinfo):


### PR DESCRIPTION
initial barrel-rotation support. -180 to +180.  Tested with Wacom
Art Pen. Requires update libmypaint to support new input.  It seems
many pens will provide bogus rotation values so a method to disable
rotation seems to be needed.  This is the GDK Wheel device which
can vary quite a bit from wheels to hockey pucks/dials, etc.  Needs updated libmypaint.
![screenshot from 2017-06-15 20-47-42](https://user-images.githubusercontent.com/6015639/27211246-dccbbbfe-520c-11e7-8fa2-cfe32f00346f.png)