### PR TITLE
Port SCons files to python3

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -14,9 +14,9 @@ mypaintlib = SConscript('lib/SConscript')
 languages = SConscript('po/SConscript')
 
 try:
-    new_umask = 022
+    new_umask = 0o22
     old_umask = os.umask(new_umask)
-    print "set umask to 0%03o (was 0%03o)" % (new_umask, old_umask)
+    print("set umask to 0%03o (was 0%03o)" % (new_umask, old_umask))
 except OSError:
     # Systems like Win32...
     pass
@@ -49,7 +49,7 @@ def burn_versions(env, target, source):
                 output.write(input.read())
     c = env.Command(target, source, [
         _burn_versions,
-        Chmod(target, 0755),
+        Chmod(target, 0o755),
     ])
     d = env.Depends(target, env.Value(env["python_binary"]))
     # But don't depend on the git output:
@@ -79,7 +79,7 @@ if os.name == "posix":
     install_perms(env,
         '$prefix/bin',
         'desktop/mypaint-ora-thumbnailer',
-        perms=0755,
+        perms=0o755,
     )
     install_perms(env,
         '$prefix/share/thumbnailers',
@@ -112,7 +112,7 @@ install_perms(env, '$prefix/share/appdata', 'desktop/mypaint.appdata.xml')
 install_perms(env, '$prefix/lib/mypaint', mypaintlib)
 
 # Program and supporting UI XML
-install_perms(env, '$prefix/bin', 'mypaint', perms=0755)
+install_perms(env, '$prefix/bin', 'mypaint', perms=0o755)
 install_perms(env, '$prefix/share/mypaint/gui', Glob('gui/*.xml'))
 install_perms(env, '$prefix/share/mypaint/gui', Glob('gui/*.glade'))
 install_perms(env, "$prefix/share/mypaint/lib",      Glob("lib/*.py"))

--- a/SConstruct
+++ b/SConstruct
@@ -17,7 +17,7 @@ elif sys.platform == "msys" and os.environ.get("MSYSTEM") != "MSYS":
     # Defaults above will work fine.
     pass
 elif os.path.exists('/etc/gentoo-release'):
-     print 'Gentoo: /etc/gentoo-release exists. Must be on a Gentoo based system.'
+     print('Gentoo: /etc/gentoo-release exists. Must be on a Gentoo based system.')
      default_python_config = 'python-config-%d.%d'  % (sys.version_info[0],sys.version_info[1])
 
 SConsignFile() # no .scsonsign into $PREFIX please
@@ -75,18 +75,18 @@ if not env.GetOption("help"):
 # Respect some standard build environment stuff
 # See http://cgit.freedesktop.org/mesa/mesa/tree/scons/gallium.py
 # See https://wiki.gentoo.org/wiki/SCons#Missing_CC.2C_CFLAGS.2C_LDFLAGS
-if os.environ.has_key('CC'):
+if 'CC' in os.environ:
    env['CC'] = os.environ['CC']
-if os.environ.has_key('CFLAGS'):
+if 'CFLAGS' in os.environ:
    env['CCFLAGS'] += SCons.Util.CLVar(os.environ['CFLAGS'])
-if os.environ.has_key('CXX'):
+if 'CXX' in os.environ:
    env['CXX'] = os.environ['CXX']
-if os.environ.has_key('CXXFLAGS'):
+if 'CXXFLAGS' in os.environ:
    env['CXXFLAGS'] += SCons.Util.CLVar(os.environ['CXXFLAGS'])
-if os.environ.has_key('CPPFLAGS'):
+if 'CPPFLAGS' in os.environ:
    env['CCFLAGS'] += SCons.Util.CLVar(os.environ['CPPFLAGS'])
    env['CXXFLAGS'] += SCons.Util.CLVar(os.environ['CPPFLAGS'])
-if os.environ.has_key('LDFLAGS'):
+if 'LDFLAGS' in os.environ:
     # LDFLAGS is omitted in SHLINKFLAGS, which is derived from LINKFLAGS
    env['LINKFLAGS'] += SCons.Util.CLVar(os.environ['LDFLAGS'])
 if "$CCFLAGS" in env['CXXCOM']:
@@ -143,7 +143,7 @@ env.Execute(Delete([
 
 
 set_dir_postaction = {}
-def install_perms(env, target, sources, perms=0644, dirperms=0755):
+def install_perms(env, target, sources, perms=0o644, dirperms=0o755):
     """As a normal env.Install, but with Chmod postactions.
 
     The `target` parameter must be a string starting with ``$prefix``.
@@ -175,7 +175,7 @@ def install_perms(env, target, sources, perms=0644, dirperms=0755):
     return install_targs
 
 
-def install_tree(env, dest, path, perms=0644, dirperms=0755):
+def install_tree(env, dest, path, perms=0o644, dirperms=0o755):
     assert os.path.isdir(path)
     target_root = join(dest, os.path.basename(path))
     for dirpath, dirnames, filenames in os.walk(path):

--- a/lib/SConscript
+++ b/lib/SConscript
@@ -109,7 +109,7 @@ if env.get("numpy_include"):
 # syntax too much, causing os.path.join() to fail.
 
 if not numpy_path:
-    numpy_cfg_py = "import numpy as np; print np.get_include()"
+    numpy_cfg_py = "import numpy as np; print(np.get_include())"
     try:
         numpy_path = subprocess.check_output([
             env["python_binary"],


### PR DESCRIPTION
using different notation for ocatal numbers,
using brackets for print()
using 'in' instead of dropped has_key

all changes are backward compatible (tested with python-2.6.9)

helps with #392 

Background: python2 will be discontinued in 2020 thus we are pushing it out of openSUSE Tumbleweed now, which causes build failures with the mypaint package now.