### PR TITLE
Reduce with-request of combo box ("active view" in the layer tab)

### DIFF
--- a/gui/layervis.glade
+++ b/gui/layervis.glade
@@ -9,7 +9,7 @@
     <property name="row_homogeneous">True</property>
     <child>
       <object class="GtkComboBox" id="current_view_combo">
-        <property name="width_request">150</property>
+        <property name="width_request">100</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="tooltip_text" translatable="yes" context="Layers window: view list controls: tooltips">The currently active view.</property>


### PR DESCRIPTION
The width request of the *view* combo box made it impossible to reduce the pencil tab to 4 brushes per row if the layer tab is placed in the same sidebar. This disturbed the order of a few brush sets.

Minimum width before:
![bildschirmfoto von 2018-04-13 19-24-28](https://user-images.githubusercontent.com/10778257/38749853-5a2c2bcc-3f53-11e8-87ef-9c9f314d1d0f.png)

And minimum width now:
![bildschirmfoto von 2018-04-13 19-43-39](https://user-images.githubusercontent.com/10778257/38749852-5a044224-3f53-11e8-84d9-b6dd04284f72.png)

.