### PR TITLE
Faster fill

### DIFF
--- a/lib/fill.cpp
+++ b/lib/fill.cpp
@@ -79,14 +79,14 @@ _floodfill_color_match(const fix15_short_t src_premult[4],
        || _floodfill_same_color(src_premult, targ_premult)) {
         return fix15_one;
     }
-    // Shortcut: If the target pixel is _fully_ transparent,
-    // the color channels are not considered
-    else if (targ_premult[3] == 0) {
-        dist = src_premult[3];
-    }
     // If only exact matches qualify, they are covered by the first conditional
     else if(tolerance == 0) {
         return 0;
+    }
+    // Shortcut: If the target pixel is _fully_ transparent,
+    // the color channels are not considered
+    if (targ_premult[3] == 0) {
+        dist = src_premult[3];
     }
     else { // Neither shortcut applied
         fix15_short_t src[4];


### PR DESCRIPTION
Summary: remove redundant tolerance check and add special cases to tolerance function + cleanup
---

Without messing around too much with checking for empty tiles and handling special cases of otherwise uniform tiles, this patch makes flood fill performance more consistent and speeds it up (for large areas) by about 2x-6x on scenarios tested on my machine (2x in the best case scenarios for the old fill, which makes sense).

The consistency is mostly down to the second commit, which removes a redundant pixel check that was almost always performed, a change that alone should be enough to avoid inconsistent and sometimes monstrous fill times for larger fill areas (scaled roughly proportional to the fill starting points proximity to top/right corner off fill area, very noticeable on large areas - e.g. 3s vs 25s for the same area in extreme cases).

Special cases are added to the tolerance function which I believe applies to most use cases of the fill tool - filling in an outline on a uniform background - often a transparent one, where the number of pixels in the fill by far outweigh the pixels of the outline (the shell of pixels encountered when filling, that is). These checks makes those fill scenarios significantly faster - especially filling with an opaque background and "sample merged" turned on, but might slow down less common (hopefully) use cases (like filling in a noisy background).

The performance differences will hardly be noticeable for small areas or on fast machines, but makes a huge difference for unlucky starting points in large areas (4k-9k pixels) and for laptop users etc.

One debatable change is discarding information about the source pixel color channels  when comparing against a fully transparent target pixel. This means that filling a transparent area constrained by e.g. a blue outline behaves the same as if that outline was any other color (but with the same alpha values).
Previously, for two otherwise identical outlines, a dark one would bleed through at a much lower tolerance than a brightly colored one, when filling from a fully transparent pixel.
To me, it doesn't make sense to consider a fully transparent pixel to have a color in this context, but the change is trivial to make.

Note: change above does not fix the jagged edges when filling transparent areas, need someone who groks the seeming non-linear nature of the alpha arithmetic for that one.