### PR TITLE
Allow modifiers while painting 

### DIFF
--- a/gui/freehand.py
+++ b/gui/freehand.py
@@ -438,14 +438,6 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
             xtilt = tilt_magnitude * math.cos(tilt_angle)
             ytilt = tilt_magnitude * math.sin(tilt_angle)
 
-        # HACK: color picking, do not paint
-        # TEST: Does this ever happen now?
-        if (state & Gdk.ModifierType.CONTROL_MASK or
-                state & Gdk.ModifierType.MOD1_MASK):
-            # Don't simply return; this is a workaround for unwanted
-            # lines in https://gna.org/bugs/?16169
-            pressure = 0.0
-
         # Apply pressure mapping if we're running as part of a full
         # MyPaint application (and if there's one defined).
         if tdw.app is not None and tdw.app.pressure_mapping:
@@ -456,11 +448,6 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
             self._hide_drawing_cursor(tdw)
         else:
             self._reinstate_drawing_cursor(tdw)
-
-        # HACK: straight line mode?
-        # TEST: Does this ever happen?
-        if state & Gdk.ModifierType.SHIFT_MASK:
-            pressure = 0.0
 
         # Queue this event
         x, y = tdw.display_to_model(x, y)


### PR DESCRIPTION
This opens up a lot more keys to control settings
like hue, sat, brightness while painting in real-time

Needs more testing, but no obviously horrible side effects yet.  It can be annoying if you are trying to use the color adjuster keys (Shift+a,s,d,f,q,w) and draw at the same time, since if you lift the pen up it will jump into line-mode.  However, I think for the people that might use this feature they will figure out pretty quick to either remap all the color adjusters, or just remove the shift+button1=line mode mapping.

IMO using naked modifers+button1 is just a bad idea, although I know it's been done for the past 30 years so it's sort of baked into people's workflow.  So, I don't know if we could remove these defaults without causing a lot of grief.

Closes #852