### PR TITLE
Real Fake Pressure and Barrel Rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 * Extensive graphic tablet support
 * Speed, simplicity, and expressiveness
 * Realistic paint-like pigment model
+* 15 bit Rec 709 linear RGB colorspace
+* Brush settings stored with each stroke on the canvas
+* Layers, various modes, and layer groups
 
 ## Build/Test/Install
 

--- a/gui/application.py
+++ b/gui/application.py
@@ -277,6 +277,11 @@ class Application (object):
         # Global pressure mapping function, ignored unless set
         self.pressure_mapping = None
 
+        # Fake inputs to send when using a mouse.  Adjustable
+        # via slider and/or hotkeys
+        self.fakepressure = 0.5
+        self.fakerotation = 0.5
+
         # App-level settings
         self._preferences = lib.observable.ObservableDict()
         self.load_settings()
@@ -360,6 +365,8 @@ class Application (object):
         #: value of that setting for the app's current brush.
         self.brush_adjustment = {}
         self.init_brush_adjustments()
+        # Extend with some fake inputs that act kind of like brush settings
+        self.fake_adjustment = {}
 
         # Connect signals defined in resources.xml
         callback_finder = CallbackFinder(signal_callback_objs)
@@ -506,7 +513,8 @@ class Application (object):
             'input.device_mode': 'screen',
             'input.global_pressure_mapping': [(0.0, 1.0), (1.0, 0.0)],
             'input.use_barrel_rotation': True,
-            'input.barrel_rotation_offset': 0.0,
+            'input.barrel_rotation_subtract_ascension': True,
+            'input.barrel_rotation_offset': 0.5,
             'view.default_zoom': 1.0,
             'view.real_alpha_checks': True,
             'ui.hide_menubar_in_fullscreen': True,
@@ -555,9 +563,10 @@ class Application (object):
             # so provide a Ctrl-based equivalent for all alt actions.
             'input.button_mapping': {
                 # Note that space is treated as a fake Button2
-                '<Shift>Button1': 'StraightMode',
-                '<Control>Button1': 'ColorPickMode',
-                '<Alt>Button1': 'ColorPickMode',
+                # It is time to free up the modifiers and Button1
+                # '<Shift>Button1': 'StraightMode',
+                # '<Control>Button1': 'ColorPickMode',
+                # '<Alt>Button1': 'ColorPickMode',
                 'Button2': 'PanViewMode',
                 '<Shift>Button2': 'RotateViewMode',
                 '<Control>Button2': 'ZoomViewMode',

--- a/gui/document.py
+++ b/gui/document.py
@@ -1466,6 +1466,54 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
 
     ## Brush settings callbacks
 
+    def fakepressure_increase_cb(self, action):
+        """``Fake Pressure Harder`` GtkAction callback"""
+        fp = self.app.fakepressure
+        self.app.fakepressure = fp * 1.1
+        current_mode = self.modes.top
+        widget = current_mode.get_options_widget()
+        try:
+            widget.fakepressure_modified_cb(self.app.fakepressure)
+        except AttributeError:
+            logger.info("Mode doesn't have fakepressure")
+            return
+
+    def fakepressure_decrease_cb(self, action):
+        """``Fake Pressure Softer`` GtkAction callback"""
+        fp = self.app.fakepressure
+        self.app.fakepressure = fp / 1.1
+        current_mode = self.modes.top
+        widget = current_mode.get_options_widget()
+        try:
+            widget.fakepressure_modified_cb(self.app.fakepressure)
+        except AttributeError:
+            logger.info("Mode doesn't have fakepressure")
+            return
+
+    def fakerotation_increase_cb(self, action):
+        """``Fake Rotation Twist Right`` GtkAction callback"""
+        fr = self.app.fakerotation
+        self.app.fakerotation = (fr + 0.0625) % 1.0
+        current_mode = self.modes.top
+        widget = current_mode.get_options_widget()
+        try:
+            widget.fakerotation_modified_cb(self.app.fakerotation)
+        except AttributeError:
+            logger.info("Mode doesn't have fakerotation")
+            return
+
+    def fakerotation_decrease_cb(self, action):
+        """``Fake Rotation Twist Left`` GtkAction callback"""
+        fr = self.app.fakerotation
+        self.app.fakerotation = (fr - 0.0625) % 1.0
+        current_mode = self.modes.top
+        widget = current_mode.get_options_widget()
+        try:
+            widget.fakerotation_modified_cb(self.app.fakerotation)
+        except AttributeError:
+            logger.info("Mode doesn't have fakerotation")
+            return
+
     def brush_bigger_cb(self, action):
         """``Bigger`` GtkAction callback"""
         adj = self.app.brush_adjustment['radius_logarithmic']

--- a/gui/resources.xml
+++ b/gui/resources.xml
@@ -231,6 +231,40 @@ Vocabulary
       </child>
       <!--}}} -->
       <!--{{{ Brush modifications -->
+      <!-- Brush fakepressure -->
+      <child>
+        <object class="GtkAction" id="FakePressureHarder">
+          <property name="label" translatable="yes" context="Menu→Brush (labels), Accel Editor (labels)">Increase Fake Pressure</property>
+          <property name="tooltip" translatable="yes" context="Accel Editor (descriptions)">Send harder pressure for devices that don't support pressure input.</property>
+          <signal name="activate" handler="fakepressure_increase_cb"/>
+        </object>
+        <accelerator key="s" modifiers="GDK_MOD1_MASK | GDK_SHIFT_MASK"/>
+      </child>
+      <child>
+        <object class="GtkAction" id="FakePressureSofter">
+          <property name="label" translatable="yes" context="Menu→Brush (labels), Accel Editor (labels)">Decrease Fake Pressure</property>
+          <property name="tooltip" translatable="yes" context="Accel Editor (descriptions)">Send softer pressure for devices that don't support pressure input.</property>
+          <signal name="activate" handler="fakepressure_decrease_cb"/>
+        </object>
+        <accelerator key="a" modifiers="GDK_MOD1_MASK | GDK_SHIFT_MASK"/>
+      </child>
+      <!-- Brush fakeprotation -->
+      <child>
+        <object class="GtkAction" id="FakeRotationIncrease">
+          <property name="label" translatable="yes" context="Menu→Brush (labels), Accel Editor (labels)">Increase Fake Rotation</property>
+          <property name="tooltip" translatable="yes" context="Accel Editor (descriptions)">Increase barrel rotation for devices that don't support rotation input.</property>
+          <signal name="activate" handler="fakerotation_increase_cb"/>
+        </object>
+        <accelerator key="f" modifiers="GDK_MOD1_MASK | GDK_SHIFT_MASK"/>
+      </child>
+      <child>
+        <object class="GtkAction" id="FakeRotationDecrease">
+          <property name="label" translatable="yes" context="Menu→Brush (labels), Accel Editor (labels)">Decrease Fake Rotation</property>
+          <property name="tooltip" translatable="yes" context="Accel Editor (descriptions)">Decrease barrel rotation for devices that don't support rotation input.</property>
+          <signal name="activate" handler="fakerotation_decrease_cb"/>
+        </object>
+        <accelerator key="d" modifiers="GDK_MOD1_MASK | GDK_SHIFT_MASK"/>
+      </child>
       <!-- Brush size -->
       <child>
         <object class="GtkAction" id="Bigger">
@@ -601,7 +635,7 @@ Vocabulary
           <property name="icon-name">mypaint-duplicate-symbolic</property>
           <signal name="activate" handler="duplicate_layer_cb"/>
         </object>
-        <accelerator key="d" modifiers="GDK_CONTROL_MASK"/>
+        <accelerator key="d" modifiers="GDK_CONTROL_MASK | GDK_SHIFT_MASK"/>
       </child>
       <child>
         <object class="GtkAction" id="LayerProperties">

--- a/setup.py
+++ b/setup.py
@@ -597,7 +597,7 @@ def get_data_files():
     # default value for install-data.
     data_files = [
         # TARGDIR, SRCFILES
-        ("appdata", ["desktop/mypaint.appdata.xml"]),
+        ("metainfo", ["desktop/mypaint.appdata.xml"]),
         ("applications", ["desktop/mypaint.desktop"]),
         ("thumbnailers", ["desktop/mypaint-ora.thumbnailer"]),
     ]


### PR DESCRIPTION
Instead of sending 0.5 pressure for
devices that don't support it, we can
send any pressure  and rotation we want
via sliders and hotkeys.  This opens up a lot
of expression for users with mice or other
unsupported devices.   Many brushes change
several settings via pressure, such as smudge.
So changing opacity alone is not a substitute.

Also, this may be unpopular, but it is time
to free up modifiers shift, control, and alt.
Having these free allows us to re-use keys
to support on-the-fly brush adjustments like
changing colors, size, opacity, etc, while
mid-stroke.