### PR TITLE
Add option for disabling layer blinking upon layer creation/selection

### DIFF
--- a/gui/document.py
+++ b/gui/document.py
@@ -1031,6 +1031,12 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
 
     ## Layer and stroke picking
 
+    def blink_layer(self, action=None):
+        if self.app.preferences.get("ui.blink_layers", True):
+            self.layerblink_state.activate(action)
+        elif self.model.layer_stack.current_layer_solo:
+            self.tdw.queue_draw()
+
     def pick_context(self, x, y, action=None):
         """Picks layer and brush
 
@@ -1053,7 +1059,7 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
                 continue
             self.model.select_layer(path=c_path)
             if c_path != old_path:
-                self.layerblink_state.activate()
+                self.blink_layer()
             # Find the most recent (last) stroke at the pick point
             si = layers.current.get_stroke_info_at(x, y)
             if si:
@@ -1087,10 +1093,10 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
             if not self._layer_is_pickable(p_path, (x, y)):
                 continue
             self.model.select_layer(path=p_path)
-            self.layerblink_state.activate(action)
+            self.blink_layer(action)
             return
         self.model.select_layer(path=(0,))
-        self.layerblink_state.activate(action)
+        self.blink_layer(action)
 
     def _layer_is_pickable(self, path, pos=None):
         """True if a (leaf) layer can be picked
@@ -1188,7 +1194,7 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
         if self.model.layer_stack.current_layer_solo:
             self.tdw.queue_draw()
         else:
-            self.layerblink_state.activate(action)
+            self.blink_layer(action)
 
     def select_layer_above_cb(self, action):
         """``SelectLayerAbove`` GtkAction callback"""
@@ -1201,7 +1207,7 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
         if self.model.layer_stack.current_layer_solo:
             self.tdw.queue_draw()
         else:
-            self.layerblink_state.activate(action)
+            self.blink_layer(action)
 
     def _update_layer_select_actions(self, *_ignored):
         """Updates the Select Layer Above/Below actions"""
@@ -1391,24 +1397,24 @@ class Document (CanvasController):  # TODO: rename to "DocumentController"
         assert path is not None
 
         self.model.add_layer(path, layer_class=layer_class, **layer_kwds)
-        self.layerblink_state.activate(action)
+        self.blink_layer(action)
         if edit_externally:
             self._begin_external_layer_edit()
 
     def merge_layer_down_cb(self, action):
         """Action callback: squash current layer into the one below it"""
         if self.model.merge_current_layer_down():
-            self.layerblink_state.activate(action)
+            self.blink_layer(action)
 
     def merge_visible_layers_cb(self, action):
         """Action callback: squash all visible layers into one"""
         self.model.merge_visible_layers()
-        self.layerblink_state.activate(action)
+        self.blink_layer(action)
 
     def new_layer_merged_from_visible_cb(self, action):
         """Action callback: combine all visible layers into a new one"""
         self.model.new_layer_merged_from_visible()
-        self.layerblink_state.activate(action)
+        self.blink_layer(action)
 
     def _update_merge_layer_down_action(self, *_ignored):
         """Updates the layer Merge Down action's sensitivity"""

--- a/gui/layerswindow.py
+++ b/gui/layerswindow.py
@@ -387,7 +387,7 @@ class LayersTool (SizedVBoxToolWidget):
         action.activate()
 
     def _blink_current_layer_cb(self, view):
-        self.app.doc.layerblink_state.activate()
+        self.app.doc.blink_layer()
 
     def _view_drag_began_cb(self, view):
         self._treeview_in_drag = True

--- a/gui/preferenceswindow.glade
+++ b/gui/preferenceswindow.glade
@@ -918,7 +918,7 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
           </object>
           <packing>
             <property name="left_attach">0</property>
-            <property name="top_attach">8</property>
+            <property name="top_attach">9</property>
             <property name="width">3</property>
           </packing>
         </child>
@@ -1095,6 +1095,39 @@ Scrolling to pan the view needs this setting to be turned on, and for your devic
             <property name="left_attach">1</property>
             <property name="top_attach">5</property>
             <property name="width">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkCheckButton" id="blink_layers_checkbutton">
+            <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|Handle smooth scrolling events|checkbox label">Enabled</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes" context="Prefs Dialog|View|Interface|Handle smooth scrolling events|checkbox tooltip">When layers are created and selected, show that layer in isolation for a short time period.</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">False</property>
+            <property name="xalign">0</property>
+            <property name="draw_indicator">True</property>
+            <signal name="toggled" handler="blink_layers_toggled_cb" swapped="no"/>
+          </object>
+          <packing>
+            <property name="left_attach">1</property>
+            <property name="top_attach">8</property>
+            <property name="width">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label40">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="hexpand">False</property>
+            <property name="vexpand">False</property>
+            <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|">Blink layers on creation/selection</property>
+            <property name="xalign">0</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">8</property>
           </packing>
         </child>
       </object>

--- a/gui/preferenceswindow.py
+++ b/gui/preferenceswindow.py
@@ -141,6 +141,11 @@ class PreferencesWindow (windowing.Dialog):
         smoothsc_checkbutton = getobj("smooth_scrolling_checkbutton")
         smoothsc_checkbutton.set_active(smoothsc)
 
+        # Blink layers on selection/creation
+        blink_layers = bool(p.get("ui.blink_layers", True))
+        blink_layers_checkbutton = getobj("blink_layers_checkbutton")
+        blink_layers_checkbutton.set_active(blink_layers)
+
         # Use real or faked alpha checks (faked is faster...)
         real_alpha_checks_checkbutton = getobj("real_alpha_checks_checkbutton")
         real_alpha_checks_checkbutton.set_active(p['view.real_alpha_checks'])
@@ -320,3 +325,7 @@ class PreferencesWindow (windowing.Dialog):
     def _hide_cursor_while_painting_toggled_cb(self, checkbut):
         hide = bool(checkbut.get_active())
         self.app.preferences["ui.hide_cursor_while_painting"] = hide
+
+    def blink_layers_toggled_cb(self, checkbut):
+        blink = bool(checkbut.get_active())
+        self.app.preferences["ui.blink_layers"] = blink


### PR DESCRIPTION
Although the feature of showing the selected layer in isolation for a short time is often useful, for my own part I find it impairs more than it helps when jumping frequently between different layers while working on them (0.8 seconds is a bit too long for my taste).

This patch simply adds an option to disable the blinking, with the default being the current behaviour.