### PR TITLE
Fix mIsc.  typos

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -301,7 +301,7 @@ export PKG_CONFIG_PATH=$BASE_DIR/lib/pkgconfig/:$BASE_DIR/share/pkgconfig/
 
 > The two colon-separated paths refer to the locations of package configuration
 > files for libmypaint and mypaint-brushes respectively. Replace the respective
-> occurence of $BASE_DIR if you installed either somewhere else.
+> occurrence of $BASE_DIR if you installed either somewhere else.
 
 In addition to knowing where libmypaint is installed _when building_,
 MyPaint also needs to know its location _when running_. This _can_ be

--- a/doc/PERFORMANCE
+++ b/doc/PERFORMANCE
@@ -129,7 +129,7 @@ the increased data to migrate to GPU may cause performance to go down?
 
 * GPU-powered brush engine. See libmypaint's PERFORMANCE too.
 
-GEGL and its GPU-side tile store, OpenCL processing would be worthwile to have a look at
+GEGL and its GPU-side tile store, OpenCL processing would be worthwhile to have a look at
 before starting any serious work in this area.
 
 

--- a/doc/spectral/spectral.md
+++ b/doc/spectral/spectral.md
@@ -9,7 +9,7 @@ The weighted geometric mean (or the weighted power mean) is a generally recogniz
 However, this only really works well with a wide multi-channel spectrum because Grassman's law no longer applies:
 * https://en.wikipedia.org/wiki/Grassmann%27s_laws_(color_science) 
 
-Additive RGB works in a linear fashion and similary to the real world, wheras Subtractive RGB is non-linear and inverts the model.
+Additive RGB works in a linear fashion and similarly to the real world, whereas Subtractive RGB is non-linear and inverts the model.
 The emissions become reflectance, and where (1,0,0) may be a perfectly valid real-world red light, it is certainly not a valid
 real-world reflectance for a natural red object.
 

--- a/gui/autorecover.glade
+++ b/gui/autorecover.glade
@@ -75,7 +75,7 @@ You can always launch this dialog from the ‘File’ menu when MyPaint is runni
             </child>
             <child>
               <object class="GtkButton" id="recover_autosave_button">
-                <property name="label" translatable="yes" context="Autosave Recovery dialog|" comments="Recover in the sense or retreival or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.">_Recover &amp; Save…</property>
+                <property name="label" translatable="yes" context="Autosave Recovery dialog|" comments="Recover in the sense or retrieval or salvage from a backup file. The user is asked to save the retrieved file immediately afterwards, hence the ellipsis.">_Recover &amp; Save…</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>

--- a/gui/blendmodehandler.py
+++ b/gui/blendmodehandler.py
@@ -38,7 +38,7 @@ class BlendMode(object):
 class BlendModes(object):
     """Proxy values for tools with individual blend mode states
 
-    Used by tool modes to mantain their own instances of active
+    Used by tool modes to maintain their own instances of active
     blend modes and blend mode history.
 
     In order to enable individual blend modes for a tool mode,

--- a/gui/fill.py
+++ b/gui/fill.py
@@ -315,8 +315,8 @@ def status_callback(handler):
     # Prevent escape release (always) triggering mode stack popping
     app.kbm.enabled = False
 
-    # Create new dialog for each occurence, hopefully
-    # occurences are rare enough for it not to matter very much.
+    # Create new dialog for each occurrence, hopefully
+    # occurrences are rare enough for it not to matter very much.
     status_dialog = Gtk.MessageDialog(
         parent=app.drawWindow, buttons=Gtk.ButtonsType.CANCEL)
 

--- a/gui/layerprops.glade
+++ b/gui/layerprops.glade
@@ -158,7 +158,7 @@ Refer to each button’s tooltip to find out what each flag does.</property>
 
 An open eye icon here indicates that the layer is visible.
 
-When the eye icon is closed, the layer is hidden. Hidden layers are completely invisible: thay have no effect on what's displayed. You cannot paint to hidden layers, for safety.
+When the eye icon is closed, the layer is hidden. Hidden layers are completely invisible: they have no effect on what's displayed. You cannot paint to hidden layers, for safety.
 
 When a layer group is hidden, all of the layers inside it are made invisible too.</property>
                 <property name="hexpand">False</property>

--- a/gui/picker.py
+++ b/gui/picker.py
@@ -105,7 +105,7 @@ class PickingGrabPresenter (object):
         statusbar.remove_all(cid)
 
     def _show_status_message(self):
-        """Display a status message vie the view."""
+        """Display a status message via the view."""
         statusbar, cid = self._statusbar_info
         statusbar.push(cid, self.picking_status_text)
 
@@ -267,7 +267,7 @@ class PickingGrabPresenter (object):
         )
         if result != Gdk.GrabStatus.SUCCESS:
             logger.error(
-                "Failed to create grab on keyboard assoiated with %r. "
+                "Failed to create grab on keyboard associated with %r. "
                 "Result: %r",
                 device.get_name(),
                 result,

--- a/gui/profiling.py
+++ b/gui/profiling.py
@@ -119,7 +119,7 @@ class Profiler (object):
                 self.DOT2PNG[0],
             )
         else:
-            logger.info("Profiling post-processing succeeed.")
+            logger.info("Profiling post-processing succeeded.")
         logger.info(
             "Opening output folder %r with the default directory viewer...",
             self._tempdir,

--- a/lib/compositing.hpp
+++ b/lib/compositing.hpp
@@ -237,7 +237,7 @@ class CompositeSpectralWGM : public CompositeFunc
                             fix15_short_t &rb, fix15_short_t &gb,
                             fix15_short_t &bb, fix15_short_t &ab) const
     {
-        // psuedo code example:
+        // pseudo code example:
         // ratio = as / as + (1 - as) * ab;
         // rgb = pow(rgb, ratio) * pow(rgb, (1-ratio));
         // ab = fix15_short_clamp(as + k);

--- a/lib/fill/floodfill.cpp
+++ b/lib/fill/floodfill.cpp
@@ -14,7 +14,7 @@
 
 /*
   Returns a list [(start, end)] of segments corresponding
-  to contiguous occurences of "true" in the given boolean array.
+  to contiguous occurrences of "true" in the given boolean array.
   This is the representation that is passed between the Python
   and C++ parts of the fill algorithm, representing, along with a
   direction marker, sequences of fill seeds to be handled.
@@ -129,7 +129,7 @@ Filler::pixel_fill_alpha(const rgba& px)
   a contiguous sequence (on the same row) already represented in the queue.
 
   Return value indicates:
-  "sequence is no longer contigous, must enqueue next eligible pixel"
+  "sequence is no longer contiguous, must enqueue next eligible pixel"
 */
 bool
 Filler::check_enqueue(

--- a/lib/layer/__init__.py
+++ b/lib/layer/__init__.py
@@ -20,7 +20,7 @@ Layer stacks are also layers in every sense, including the root one,
 and are subject to the same constraints.
 The root stack is owned by the document model.
 Layers must be unique within the tree structure,
-although this constrant is not enforced.
+although this constraint is not enforced.
 
 Layers emit a moderately fine-grained set of notifications
 when the structure changes, or when the user draws something.

--- a/lib/morphology.py
+++ b/lib/morphology.py
@@ -83,7 +83,7 @@ def strand_partition(tiles, dilating=False):
             # Either beginning of new strand, or adds to existing one
             strand.append(tile_coord)
         else:
-            # Neither final, nor contigous, begin new strand
+            # Neither final, nor contiguous, begin new strand
             strands.append(strand)
             strand = [tile_coord]
         previous = tile_coord

--- a/lib/palette.py
+++ b/lib/palette.py
@@ -404,7 +404,7 @@ class Palette (object):
 
         :param direction: Direction for moving, positive or negative
         :type direction: int:, ``1`` or ``-1``
-        :param refcol: Reference color, used for initial mathing when needed.
+        :param refcol: Reference color, used for initial matching when needed.
         :type refcol: lib.color.UIColor
         :returns: the color newly matched, if the match position has changed
         :rtype: lib.color.UIColor, or None

--- a/po/SConscript
+++ b/po/SConscript
@@ -107,7 +107,7 @@ if lang:
         # Update the .pot file only.
         # Handy for doing local diffs,
         # but it's best not to commit alone - .po files on
-        # WebLate sould be kept in sync with their .pot.
+        # WebLate should be kept in sync with their .pot.
         env.Execute(build_potfiles_in)
         env.Execute([
             ["intltool-update", "-g", "mypaint", "--pot"],

--- a/po/update_potfiles.sh
+++ b/po/update_potfiles.sh
@@ -9,7 +9,7 @@ OUTFILE=POTFILES.in
 mkdir -p "tmp"
 
 # List Python code that imports either the standard gettext module, or
-# our GLib-based compat mocules that supports C_(). Intltool-update
+# our GLib-based compat modules that supports C_(). Intltool-update
 # knows about python code using syntax like the C macros.
 
 git grep --full-name --files-with-matches "^from gettext import" .. \


### PR DESCRIPTION
Found via `codespell -i 3 -w -S *.po -L hist,od`