### PR TITLE
Backwards compatibility w. 1.x

### DIFF
--- a/gui/application.py
+++ b/gui/application.py
@@ -47,6 +47,7 @@ from gettext import gettext as _
 import lib.observable
 import lib.cache
 import lib.document
+import lib.eotf
 from lib import brush
 from lib import helpers
 from lib import mypaintlib
@@ -275,6 +276,10 @@ class Application (object):
         self._preferences = lib.observable.ObservableDict()
         self.load_settings()
 
+        # Initiate eotf
+        lib.eotf.set_eotf(self.eotf_default)
+        lib.eotf.set_base_eotf(self.eotf_default)
+
         # Unmanaged main brush.
         # Always the same instance (we can attach settings_observers).
         # This brush is where temporary changes (color, size...) happen.
@@ -426,6 +431,29 @@ class Application (object):
 
         """
         return self._preferences
+
+    @property
+    def eotf(self):
+        """Electro-optical transfer function
+
+        Used for transforming pixel data on loading and rendering.
+        Ora files created in MyPaint <= 1.2.1 need this value to be
+        set to 1.0 rather than the current default (2.2) in order to
+        look the same as they did in the older version of MyPaint.
+        :rtype: float
+        """
+        return lib.eotf.eotf()
+
+    @property
+    def eotf_default(self):
+        """Electro-optical transfer function default value
+
+        This is the default value in terms of user settings,
+        it is session-default, but not necessarily constant.
+        """
+        return self._preferences.get(
+            'display.colorspace_EOTF', lib.eotf.DEFAULT_EOTF
+        )
 
     def _at_application_start(self, filenames, fullscreen):
         col = self.brush_color_manager.get_color()

--- a/gui/brushmanager.py
+++ b/gui/brushmanager.py
@@ -209,7 +209,8 @@ class BrushManager (object):
         super(BrushManager, self).__init__()
 
         # Default pigment setting when not specified by the brush
-        self.pigment_by_default = True
+        self.pigment_by_default = None
+
         self.stock_brushpath = stock_brushpath
         self.user_brushpath = user_brushpath
         self.app = app
@@ -576,6 +577,9 @@ class BrushManager (object):
         do not have the pigment setting set explicitly.
         """
         if self.pigment_by_default != pigment_by_default:
+            msg = "Switching default pigment setting to {state}"
+            logger.info(msg.format(
+                state="On" if pigment_by_default else "Off"))
             self.pigment_by_default = pigment_by_default
             self._reset_pigment_setting()
 

--- a/gui/compatibility.py
+++ b/gui/compatibility.py
@@ -1,0 +1,353 @@
+# This file is part of MyPaint.
+# Copyright (C) 2019 by the MyPaint Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from logging import getLogger
+
+from gi.repository import Gtk
+
+import lib.eotf
+from lib.layer.data import BackgroundLayer
+from lib.modes import MODE_STRINGS, set_default_mode
+from lib.mypaintlib import CombineNormal, CombineSpectralWGM
+from lib.mypaintlib import combine_mode_get_info
+from lib.gettext import C_
+
+logger = getLogger(__name__)
+
+# Keys for settings in the user preferences
+DEFAULT_COMPAT = 'default_compatibility_mode'
+COMPAT_SETTINGS = 'compability_settings'
+
+# Keys for compat mode sub-options in the user preferences
+PIGMENT_BY_DEFAULT = 'pigment_on_by_default'
+PIGMENT_LAYER_BY_DEFAULT = 'pigment_layer_is_default'
+
+C1X = '1.x'
+C2X = '2.x'
+
+
+_PIGMENT_OP = combine_mode_get_info(CombineSpectralWGM)['name']
+
+
+def has_pigment_layers(elem):
+    """Check if the layer stack xml contains a pigment layer
+
+    Has to be done before any layers are loaded, since the
+    correct eotf value needs to set before loading the tiles.
+    """
+    # Ignore the composite op of the background.
+    # We only need to check for the namespaced attribute, as
+    # any file containing the non-namespaced counterpart was
+    # created prior (version-wise) to pigment layers.
+    bg_attr = BackgroundLayer.ORA_BGTILE_ATTR
+    if elem.get(bg_attr, None):
+        return False
+    op = elem.attrib.get('composite-op', None)
+    return op == _PIGMENT_OP or any([has_pigment_layers(c) for c in elem])
+
+
+class CompatFileBehavior:
+    """ Holds data and functions related to per-file choice of compat mode
+    """
+
+    # Key for the behavior setting in user preferences
+    SETTING = 'compat_behavior_when_unknown'
+
+    # Setting options
+    ALWAYS_1X = 'always-1.x'
+    ALWAYS_2X = 'always-2.x'
+    UNLESS_PIGMENT_LAYER_1X = 'unless-pigment-layer-1.x'
+
+    _OPTIONS = [
+        ALWAYS_1X,
+        ALWAYS_2X,
+        UNLESS_PIGMENT_LAYER_1X,
+    ]
+    _LABELS = {
+        ALWAYS_1X: (
+            C_(
+                "Prefs Dialog|Compatibility",
+                # TRANSLATORS: One of the options for the
+                # TRANSLATORS: "When Not Specified in File"
+                # TRANSLATORS: compatibility setting.
+                "Always open in 1.x mode"
+            )
+        ),
+        ALWAYS_2X: (
+            C_(
+                "Prefs Dialog|Compatibility",
+                # TRANSLATORS: One of the options for the
+                # TRANSLATORS: "When Not Specified in File"
+                # TRANSLATORS: compatibility setting.
+                "Always open in 2.x mode"
+            )
+        ),
+        UNLESS_PIGMENT_LAYER_1X: (
+            C_(
+                "Prefs Dialog|Compatibility",
+                # TRANSLATORS: One of the options for the
+                # TRANSLATORS: "When Not Specified in File"
+                # TRANSLATORS: compatibility setting.
+                "Open in 1.x mode unless file contains pigment layers"
+            )
+        ),
+    }
+
+    def __init__(self, combobox, prefs):
+        self.combo = combobox
+        self.prefs = prefs
+        options_store = Gtk.ListStore()
+        options_store.set_column_types((str, str))
+        for option in self._OPTIONS:
+            options_store.append((option, self._LABELS[option]))
+        combobox.set_model(options_store)
+
+        cell = Gtk.CellRendererText()
+        combobox.pack_start(cell, True)
+        combobox.add_attribute(cell, 'text', 1)
+        self.update_ui()
+        combobox.connect('changed', self.changed_cb)
+
+    def update_ui(self):
+        self.combo.set_active_id(self.prefs[self.SETTING])
+
+    def changed_cb(self, combo):
+        active_id = self.combo.get_active_id()
+        self.prefs[self.SETTING] = active_id
+
+    @staticmethod
+    def get_compat_mode(setting, root_elem, default):
+        """ Get the compat mode to use for a file
+
+        The decision is based on the given file behavior setting
+        and the layer stack xml.
+        """
+        # If more options are added, rewrite to use separate classes.
+        if setting == CompatFileBehavior.ALWAYS_1X:
+            return C1X
+        elif setting == CompatFileBehavior.ALWAYS_2X:
+            return C2X
+        elif setting == CompatFileBehavior.UNLESS_PIGMENT_LAYER_1X:
+            if has_pigment_layers(root_elem):
+                logger.info("Pigment layer found!")
+                return C2X
+            else:
+                return C1X
+        else:
+            msg = "Unknown file compat setting: {setting}, using default mode."
+            logger.warning(msg.format(setting=setting))
+            return default
+
+
+# Default compatibility settings
+DEFAULT_CONFIG = {
+    CompatFileBehavior.SETTING: CompatFileBehavior.UNLESS_PIGMENT_LAYER_1X,
+    DEFAULT_COMPAT: C2X,
+    COMPAT_SETTINGS: {
+        C1X: {
+            PIGMENT_BY_DEFAULT: False,
+            PIGMENT_LAYER_BY_DEFAULT: False,
+        },
+        C2X: {
+            PIGMENT_BY_DEFAULT: True,
+            PIGMENT_LAYER_BY_DEFAULT: True,
+        },
+    },
+}
+
+
+class CompatibilityPreferences:
+    """ A single instance should be a part of the preference window
+
+    This class handles preferences related to the compatibility modes
+    and their settings.
+    """
+
+    def __init__(self, app, builder):
+        self.app = app
+        self._builder = builder
+        # Widget references
+        getobj = builder.get_object
+        # Default compat mode choice radio buttons
+        self.default_radio_1_x = getobj('compat_1_x_radiobutton')
+        self.default_radio_2_x = getobj('compat_2_x_radiobutton')
+        # For each mode, choice for whether pigment is on or off by default
+        self.pigment_switch_1_x = getobj('pigment_setting_switch_1_x')
+        self.pigment_switch_2_x = getobj('pigment_setting_switch_2_x')
+        # For each mode, choice of which layer type is the default
+        self.pigment_radio_1_x = getobj('def_new_layer_pigment_1_x')
+        self.pigment_radio_2_x = getobj('def_new_layer_pigment_2_x')
+        self.normal_radio_1_x = getobj('def_new_layer_normal_1_x')
+        self.normal_radio_2_x = getobj('def_new_layer_normal_2_x')
+
+        self.compat_file_behavior = CompatFileBehavior(
+            getobj('compat_file_behavior_combobox'), self.app.preferences)
+        # Initialize widgets and callbacks
+        self.setup_layer_type_strings()
+        self.setup_widget_callbacks()
+
+    def setup_widget_callbacks(self):
+        """ Hook up callbacks for switches and radiobuttons
+        """
+        # Convenience wrapper - here it is enough to act when toggling on,
+        # so ignore callbacks triggered by radio buttons being toggled off.
+        def ignore_detoggle(cb_func):
+            def cb(btn, *args):
+                if btn.get_active():
+                    cb_func(btn, *args)
+            return cb
+
+        # Connect default layer type toggles
+        layer_type_cb = ignore_detoggle(self.set_compat_layer_type_cb)
+        self.normal_radio_1_x.connect('toggled', layer_type_cb, C1X, False)
+        self.pigment_radio_1_x.connect('toggled', layer_type_cb, C1X, True)
+        self.normal_radio_2_x.connect('toggled', layer_type_cb, C2X, False)
+        self.pigment_radio_2_x.connect('toggled', layer_type_cb, C2X, True)
+
+        def_compat_cb = ignore_detoggle(self.set_default_compat_mode_cb)
+        self.default_radio_1_x.connect('toggled', def_compat_cb, C1X)
+        self.default_radio_2_x.connect('toggled', def_compat_cb, C2X)
+
+        pigment_switch_cb = self.default_pigment_changed_cb
+        self.pigment_switch_1_x.connect('state-set', pigment_switch_cb, C1X)
+        self.pigment_switch_2_x.connect('state-set', pigment_switch_cb, C2X)
+
+    def setup_layer_type_strings(self):
+        """ Replace the placeholder labels and add tooltips
+        """
+        def string_setup(widget, label, tooltip):
+            widget.set_label(label)
+            widget.set_tooltip_text(tooltip)
+
+        normal_label, normal_tooltip = MODE_STRINGS[CombineNormal]
+        string_setup(self.normal_radio_1_x, normal_label, normal_tooltip)
+        string_setup(self.normal_radio_2_x, normal_label, normal_tooltip)
+        pigment_label, pigment_tooltip = MODE_STRINGS[CombineSpectralWGM]
+        string_setup(self.pigment_radio_1_x, pigment_label, pigment_tooltip)
+        string_setup(self.pigment_radio_2_x, pigment_label, pigment_tooltip)
+
+    def update_ui(self):
+        prefs = self.app.preferences
+        # Even in a radio button group with 2 widgets, using set_active(False)
+        # will not toggle the other button on, hence this ugly pattern.
+        if prefs.get(DEFAULT_COMPAT, C2X) == C1X:
+            self.default_radio_1_x.set_active(True)
+        else:
+            self.default_radio_2_x.set_active(True)
+        mode_settings = prefs[COMPAT_SETTINGS]
+        # 1.x
+        self.pigment_switch_1_x.set_active(
+            mode_settings[C1X][PIGMENT_BY_DEFAULT])
+        if mode_settings[C1X][PIGMENT_LAYER_BY_DEFAULT]:
+            self.pigment_radio_1_x.set_active(True)
+        else:
+            self.normal_radio_1_x.set_active(True)
+        # 2.x
+        self.pigment_switch_2_x.set_active(
+            mode_settings[C2X][PIGMENT_BY_DEFAULT])
+        if mode_settings[C2X][PIGMENT_LAYER_BY_DEFAULT]:
+            self.pigment_radio_2_x.set_active(True)
+        else:
+            self.normal_radio_2_x.set_active(True)
+
+    def _update_prefs(self, mode, setting, value):
+        prefs = self.app.preferences
+        prefs[COMPAT_SETTINGS][mode].update({setting: value})
+
+    # Widget callbacks
+
+    def set_default_compat_mode_cb(self, radiobutton, compat_mode):
+        self.app.preferences[DEFAULT_COMPAT] = compat_mode
+
+    def set_compat_layer_type_cb(self, btn, mode, use_pigment):
+        self._update_prefs(mode, PIGMENT_LAYER_BY_DEFAULT, use_pigment)
+        update_default_layer_type(self.app)
+
+    def default_pigment_changed_cb(self, switch, use_pigment, mode):
+        self._update_prefs(mode, PIGMENT_BY_DEFAULT, use_pigment)
+        update_default_pigment_setting(self.app)
+
+
+def ora_compat_handler(app):
+    def handler(eotf_value, root_stack_elem):
+        default = app.preferences[DEFAULT_COMPAT]
+        if eotf_value is not None:
+            try:
+                eotf_value = float(eotf_value)
+                compat = C1X if eotf_value == 1.0 else C2X
+            except ValueError:
+                msg = "Invalid eotf: {eotf}, using default compat mode!"
+                logger.warning(msg.format(eotf=eotf_value))
+                eotf_value = None
+                compat = default
+        else:
+            logger.info("No eotf value specified in openraster file")
+            # Depending on user settings, decide whether to
+            # use the default value for the eotf, or the legacy value of 1.0
+            setting = app.preferences[CompatFileBehavior.SETTING]
+            compat = CompatFileBehavior.get_compat_mode(
+                setting, root_stack_elem, default)
+        set_compat_mode(app, compat, custom_eotf=eotf_value)
+    return handler
+
+
+def set_compat_mode(app, compat_mode, custom_eotf=None, update=True):
+    """Set compatibility mode
+
+    Set compatibility mode and update associated settings;
+    default pigment brush setting and default layer type.
+    If the "update" keyword is set to False, the settings
+    are not updated.
+
+    If the compatibility mode is changed, the scratchpad is
+    saved and reloaded under the new mode settings.
+    """
+    if compat_mode not in {C1X, C2X}:
+        compat_mode = C2X
+        msg = "Unknown compatibility mode: '{mode}'! Using 2.x instead."
+        logger.warning(msg.format(mode=compat_mode))
+    changed = compat_mode != app.compat_mode
+    app.compat_mode = compat_mode
+    # Save scratchpad (with current eotf)
+    if update and changed:
+        app.drawWindow.save_current_scratchpad_cb(None)
+    # Change eotf and set new compat mode
+    if compat_mode == C1X:
+        logger.info("Setting mode to 1.x (legacy)")
+        lib.eotf.set_eotf(1.0)
+    else:
+        logger.info("Setting mode to 2.x (standard)")
+        lib.eotf.set_eotf(custom_eotf or lib.eotf.base_eotf())
+    if update and changed:
+        # Reload scratchpad (with new eotf)
+        app.drawWindow.revert_current_scratchpad_cb(None)
+        update_default_layer_type(app)
+        update_default_pigment_setting(app)
+
+
+def update_default_layer_type(app):
+    """Update default layer type from settings
+    """
+    prefs = app.preferences
+    mode_settings = prefs[COMPAT_SETTINGS][app.compat_mode]
+    if mode_settings[PIGMENT_LAYER_BY_DEFAULT]:
+        logger.info("Setting default layer type to Pigment")
+        set_default_mode(CombineSpectralWGM)
+    else:
+        logger.info("Setting default layer type to Normal")
+        set_default_mode(CombineNormal)
+
+
+def update_default_pigment_setting(app):
+    """Update default pigment brush setting value
+    """
+    prefs = app.preferences
+    mode_settings = prefs[COMPAT_SETTINGS][app.compat_mode]
+    app.brushmanager.set_pigment_by_default(
+        mode_settings[PIGMENT_BY_DEFAULT]
+    )

--- a/gui/compatibility.py
+++ b/gui/compatibility.py
@@ -472,6 +472,8 @@ def set_compat_mode(app, compat_mode, custom_eotf=None, update=True):
     if update and changed:
         # Reload scratchpad (with new eotf)
         app.drawWindow.revert_current_scratchpad_cb(None)
+        for f in app.brush.observers:
+            f({'color_h', 'color_s', 'color_v'})
         update_default_layer_type(app)
         update_default_pigment_setting(app)
 

--- a/gui/drawwindow.py
+++ b/gui/drawwindow.py
@@ -29,6 +29,7 @@ import xml.etree.ElementTree as ET
 from gi.repository import Gtk
 from gi.repository import Gdk
 
+from . import compatibility
 from . import historypopup
 from . import stategroup
 from . import colorpicker  # noqa: F401 (registration of GObject classes)
@@ -266,10 +267,16 @@ class DrawWindow (Gtk.Window):
     def update_title(self, filename):
         if filename:
             # TRANSLATORS: window title for use with a filename
-            self.set_title(_("%s - MyPaint") % os.path.basename(filename))
+            title_base = _("%s - MyPaint") % os.path.basename(filename)
         else:
             # TRANSLATORS: window title for use without a filename
-            self.set_title(_("MyPaint"))
+            title_base = _("MyPaint")
+        # Show whether legacy 1.x compatibility mode is active
+        if self.app.compat_mode == compatibility.C1X:
+            compat_str = " (%s)" % C_("Prefs Dialog|Compatibility", "1.x")
+        else:
+            compat_str = ""
+        self.set_title(title_base + compat_str)
 
     def _drag_data_received_cb(self, widget, context, x, y, data, info, time):
         """Handles data being received"""

--- a/gui/filehandling.py
+++ b/gui/filehandling.py
@@ -825,7 +825,7 @@ class FileHandler (object):
     def open_file(self, filename, **kwargs):
         """Load a file, replacing the current working document."""
         if not self._call_doc_load_method(
-                self.doc.model.load, filename, False):
+                self.doc.model.load, filename, False, **kwargs):
             # Without knowledge of _when_ the process failed, clear
             # the document to make sure we're not in an inconsistent state.
             # TODO: Improve the control flow to permit a less draconian
@@ -1042,6 +1042,11 @@ class FileHandler (object):
         dialog.add_button(Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
         dialog.set_default_response(Gtk.ResponseType.OK)
 
+        # Compatibility override options for .ora files
+        selector = compat.CompatSelector(self.app)
+        dialog.connect('selection-changed', selector.file_selection_changed_cb)
+        dialog.set_extra_widget(selector.widget)
+
         preview = Gtk.Image()
         dialog.set_preview_widget(preview)
         dialog.connect("update-preview", self.update_preview_cb, preview)
@@ -1065,7 +1070,10 @@ class FileHandler (object):
                 dialog.hide()
                 filename = dialog.get_filename()
                 filename = filename_to_unicode(filename)
-                self.open_file(filename)
+                self.open_file(
+                    filename,
+                    compat_handler=selector.compat_function
+                )
         finally:
             dialog.destroy()
 

--- a/gui/fill.py
+++ b/gui/fill.py
@@ -678,8 +678,8 @@ class FloodFillOptionsWidget (Gtk.Grid):
         self._bm_warning_label = (label, 0, row, 1, 1)
 
         modes = list(lib.modes.STANDARD_MODES)
-        modes.remove(lib.modes.DEFAULT_MODE)
-        modes.insert(0, lib.modes.DEFAULT_MODE)
+        modes.remove(lib.mypaintlib.CombineSpectralWGM)
+        modes.insert(0, lib.mypaintlib.CombineSpectralWGM)
         combo = gui.layers.new_blend_mode_combo(modes, lib.modes.MODE_STRINGS)
         combo.set_tooltip_text(C_(
             "fill options: Target | Blend Mode dropdown (tooltip)",

--- a/gui/fill.py
+++ b/gui/fill.py
@@ -203,10 +203,6 @@ class FloodFillMode (
         If the current layer is not fillable, a new layer will always be
         created for the fill.
         """
-        try:
-            self.EOTF = self.app.preferences['display.colorspace_EOTF']
-        except: 
-            self.EOTF = 2.2
         self._tdws.add(tdw)
         self._update_ui()
         color = self.doc.app.brush_color_manager.get_color()
@@ -215,8 +211,10 @@ class FloodFillMode (
         rootstack = tdw.doc.layer_stack
         if not rootstack.current.get_fillable():
             make_new_layer = True
+        eotf = self.app.eotf
         rgb = color.get_rgb()
-        rgb = (rgb[0]**self.EOTF, rgb[1]**self.EOTF, rgb[2]**self.EOTF)
+        if eotf != 1.0:
+            rgb = (rgb[0]**eotf, rgb[1]**eotf, rgb[2]**eotf)
         view_bbox = None
         if opts.limit_to_view:
             corners = tdw.get_corners_model_coords()

--- a/gui/fill.py
+++ b/gui/fill.py
@@ -27,6 +27,7 @@ from gui.blendmodehandler import BlendModes
 import gui.layers
 import gui.overlays
 
+import lib.eotf
 import lib.floodfill
 import lib.helpers
 import lib.mypaintlib
@@ -211,7 +212,7 @@ class FloodFillMode (
         rootstack = tdw.doc.layer_stack
         if not rootstack.current.get_fillable():
             make_new_layer = True
-        eotf = self.app.eotf
+        eotf = lib.eotf.eotf()
         rgb = color.get_rgb()
         if eotf != 1.0:
             rgb = (rgb[0]**eotf, rgb[1]**eotf, rgb[2]**eotf)

--- a/gui/layers.py
+++ b/gui/layers.py
@@ -936,7 +936,7 @@ class RootStackTreeView (Gtk.TreeView):
 
             # Mode (if it's interesting)
             if layer.mode in lib.modes.MODE_STRINGS:
-                if layer.mode != lib.modes.DEFAULT_MODE:
+                if layer.mode != lib.modes.default_mode():
                     s, d = lib.modes.MODE_STRINGS[layer.mode]
                     desc_parts.append(s)
             else:

--- a/gui/layerswindow.py
+++ b/gui/layerswindow.py
@@ -32,7 +32,7 @@ from lib.modes import STACK_MODES
 from lib.modes import STANDARD_MODES
 from lib.modes import MODE_STRINGS
 from lib.modes import PASS_THROUGH_MODE
-from lib.modes import DEFAULT_MODE
+import lib.modes
 import gui.layervis
 
 logger = getLogger(__name__)
@@ -176,8 +176,8 @@ class LayersTool (SizedVBoxToolWidget):
         row += 1
         # ComboBox w/ list model (mode_num, label, sensitive, scale)
         modes = list(STACK_MODES + STANDARD_MODES)
-        modes.remove(DEFAULT_MODE)
-        modes.insert(0, DEFAULT_MODE)
+        modes.remove(lib.mypaintlib.CombineSpectralWGM)
+        modes.insert(0, lib.mypaintlib.CombineSpectralWGM)
         combo = layers.new_blend_mode_combo(modes, MODE_STRINGS)
         self._layer_mode_combo = combo
         grid.attach(combo, 0, row, 5, 1)

--- a/gui/preferenceswindow.glade
+++ b/gui/preferenceswindow.glade
@@ -89,6 +89,8 @@
     <property name="visible">True</property>
     <property name="can_focus">True</property>
     <property name="border_width">12</property>
+    <property name="scrollable">True</property>
+    <property name="enable_popup">True</property>
     <child>
       <object class="GtkFrame" id="frame7">
         <property name="visible">True</property>
@@ -297,13 +299,13 @@
                   <object class="GtkLabel" id="label33">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="yalign">0</property>
                     <property name="label" translatable="yes" context="Prefs Dialog|Devices|">Here you can restrict pointing devices to specific tasks on the canvas, or have them ignored completely if they glitch your drawing.</property>
                     <property name="wrap">True</property>
                     <property name="wrap_mode">word-char</property>
                     <property name="width_chars">40</property>
                     <property name="max_width_chars">60</property>
+                    <property name="xalign">0</property>
+                    <property name="yalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -375,12 +377,12 @@
                   <object class="GtkLabel" id="label1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="yalign">0</property>
                     <property name="label" translatable="yes" context="Prefs Dialog|Button|Pointer Button Mappings|">• The space bar can be used like Button2.
 • Some tablet pads' buttons cannot be held down when pressed.</property>
                     <property name="wrap">True</property>
                     <property name="wrap_mode">word-char</property>
+                    <property name="xalign">0</property>
+                    <property name="yalign">0</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -475,8 +477,8 @@
             <property name="margin_left">12</property>
             <property name="margin_right">12</property>
             <property name="hexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|Saving|">Default file format:</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -490,8 +492,8 @@
             <property name="margin_left">12</property>
             <property name="margin_right">12</property>
             <property name="hexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|Saving|">Prefix when saving scraps:</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -541,9 +543,9 @@
             <property name="can_focus">False</property>
             <property name="hexpand">True</property>
             <property name="vexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|">&lt;b&gt;Saving&lt;/b&gt;</property>
             <property name="use_markup">True</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -558,9 +560,9 @@
             <property name="margin_top">18</property>
             <property name="hexpand">True</property>
             <property name="vexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|">&lt;b&gt;Color Management&lt;/b&gt;</property>
             <property name="use_markup">True</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -574,9 +576,9 @@
             <property name="can_focus">False</property>
             <property name="margin_left">12</property>
             <property name="hexpand">False</property>
+            <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|Color Management|">Color space conversions:</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|Color Management|">Color space conversions:</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -599,7 +601,9 @@
                 <property name="tooltip_markup" translatable="yes" context="Prefs Dialog|Load &amp; Save|Color Management|">Images containing &lt;i&gt;full&lt;/i&gt; colorspace information will be converted to sRGB when they are loaded into MyPaint. When MyPaint saves an image, hints will be added to it so that other programs can render it properly.
 
 This assumes that the display is calibrated to something close to sRGB, the standard colour space for the web and a pessimistic approximation of most PC monitors. If you know your display is radically different from this, use the "no automatic conversions or tagging" setting instead.</property>
+                <property name="valign">start</property>
                 <property name="xalign">0</property>
+                <property name="yalign">0.49000000953674316</property>
                 <property name="active">True</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="display_colorspace_srgb_radiobutton_toggled_cb" swapped="no"/>
@@ -644,9 +648,9 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="margin_top">18</property>
             <property name="hexpand">True</property>
             <property name="vexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|">&lt;b&gt;Automated Backups&lt;/b&gt;</property>
             <property name="use_markup">True</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -662,9 +666,9 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="margin_left">12</property>
             <property name="margin_right">12</property>
             <property name="hexpand">False</property>
+            <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|Automated Backups|switch label">Back up unsaved work:</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|Automated Backups|switch label">Back up unsaved work:</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -697,9 +701,9 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="margin_left">6</property>
             <property name="margin_right">6</property>
             <property name="hexpand">True</property>
+            <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|Automated Backups|interval spinbox units suffix" comments="In seconds. Lowest value is 5, highest is 300 (5 minutes). Only matters when enabled.">seconds of inactivity</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|Automated Backups|interval spinbox units suffix" comments="In seconds. Lowest value is 5, highest is 300 (5 minutes). Only matters when enabled.">seconds of inactivity</property>
           </object>
           <packing>
             <property name="left_attach">2</property>
@@ -732,9 +736,9 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="margin_left">12</property>
             <property name="margin_right">12</property>
             <property name="hexpand">False</property>
+            <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|Automated Backups|interval label">Time between backups:</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="label" translatable="yes" context="Prefs Dialog|Load &amp; Save|Automated Backups|interval label">Time between backups:</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -771,9 +775,9 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="can_focus">False</property>
             <property name="hexpand">True</property>
             <property name="vexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes" context="Prefs Dialog|View|">&lt;b&gt;Zoom and Rendering&lt;/b&gt;</property>
             <property name="use_markup">True</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -788,8 +792,8 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="margin_left">12</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes">Default zoom level:</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -826,9 +830,9 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="margin_top">18</property>
             <property name="hexpand">True</property>
             <property name="vexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes" context="Prefs Dialog|View|">&lt;b&gt;Interface&lt;/b&gt;</property>
             <property name="use_markup">True</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -843,9 +847,9 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="margin_left">12</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
+            <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|">Toolbar icon size:</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|">Toolbar icon size:</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -859,8 +863,8 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="margin_left">12</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|">Freehand cursor type:</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -874,8 +878,8 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="margin_left">12</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|">Dark theme variant:</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -913,7 +917,7 @@ This is MyPaint's old behaviour, and can be used as a stopgap for non-sRGB worki
             <property name="wrap">True</property>
             <attributes>
               <attribute name="style" value="italic"/>
-              <attribute name="scale" value="0.8"/>
+              <attribute name="scale" value="0.80000000000000004"/>
             </attributes>
           </object>
           <packing>
@@ -999,8 +1003,8 @@ This slows down the display, but can be less confusing.</property>
             <property name="margin_left">12</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes">When showing transparency:</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -1014,8 +1018,8 @@ This slows down the display, but can be less confusing.</property>
             <property name="margin_left">12</property>
             <property name="hexpand">False</property>
             <property name="vexpand">False</property>
-            <property name="xalign">0</property>
             <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|">Handle smooth scrolling events:</property>
+            <property name="xalign">0</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -1080,7 +1084,6 @@ Scrolling to pan the view needs this setting to be turned on, and for your devic
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="xalign">0</property>
-                <property name="yalign">0.5</property>
                 <property name="draw_indicator">True</property>
                 <signal name="toggled" handler="_hide_cursor_while_painting_toggled_cb" swapped="no"/>
               </object>
@@ -1160,7 +1163,6 @@ Scrolling to pan the view needs this setting to be turned on, and for your devic
             <property name="vexpand">False</property>
             <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|">Language:</property>
             <property name="xalign">0</property>
-            <property name="yalign">0.5</property>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -1176,7 +1178,6 @@ Scrolling to pan the view needs this setting to be turned on, and for your devic
             <property name="vexpand">False</property>
             <property name="label" translatable="yes" context="Prefs Dialog|View|Interface|">(needs restart)</property>
             <property name="xalign">0</property>
-            <property name="yalign">0.5</property>
           </object>
           <packing>
             <property name="left_attach">2</property>
@@ -1226,9 +1227,9 @@ Scrolling to pan the view needs this setting to be turned on, and for your devic
                     <property name="can_focus">False</property>
                     <property name="tooltip_text" translatable="yes" context="Prefs Dialog|Color|Color Wheel|Primaries|">The set of colors to show as primary on disk-style color wheels.
 Different traditions have different color harmonies.</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Color|Color Wheel|" comments="Arrangement of MyPaint's custom colour wheels">Primaries are:</property>
                     <property name="xalign">0</property>
                     <property name="yalign">0</property>
-                    <property name="label" translatable="yes" context="Prefs Dialog|Color|Color Wheel|" comments="Arrangement of MyPaint's custom colour wheels">Primaries are:</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
@@ -1252,6 +1253,7 @@ Different traditions have different color harmonies.</property>
                         <property name="tooltip_text" translatable="yes" context="Prefs Dialog|Color|Color Wheel|Primaries|RGB|">The red, green, and blue 'computer monitor' primaries, evenly arranged around the circle. Green is opposite magenta.</property>
                         <property name="hexpand">True</property>
                         <property name="xalign">0</property>
+                        <property name="yalign">0.51999998092651367</property>
                         <property name="active">True</property>
                         <property name="draw_indicator">True</property>
                         <signal name="toggled" handler="color_wheel_rgb_radiobutton_toggled_cb" swapped="no"/>
@@ -1337,6 +1339,339 @@ Different traditions have different color harmonies.</property>
       </object>
       <packing>
         <property name="position">6</property>
+        <property name="tab_fill">False</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkFrame" id="compat_frame">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="valign">start</property>
+        <property name="border_width">12</property>
+        <property name="label_xalign">0</property>
+        <property name="shadow_type">none</property>
+        <child>
+          <object class="GtkAlignment" id="alignment2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="xalign">1</property>
+            <property name="top_padding">12</property>
+            <property name="left_padding">12</property>
+            <child>
+              <object class="GtkGrid" id="grid2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="row_spacing">12</property>
+                <child>
+                  <object class="GtkLabel" id="def_compat_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_right">12</property>
+                    <property name="label" translatable="yes">Default Compatibility Mode:</property>
+                    <property name="justify">right</property>
+                    <property name="ellipsize">end</property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSeparator" id="separator1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label_1_x_settings">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility">&lt;b&gt;1.x Settings&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">3</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label_2_x_settings">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility" comments="Make sure to be consistent w. other occurences of 2.x">&lt;b&gt;2.x Settings&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">8</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSeparator" id="separator3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="valign">start</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">7</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="pigment_setting_switch_1_x">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="halign">start</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="pigm_brsh_label1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_right">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compat">Default New Layer Type:</property>
+                    <property name="ellipsize">middle</property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">5</property>
+                    <property name="height">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="def_new_layer_normal_1_x">
+                    <property name="label">&lt;placeholder - normal&gt;</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="xalign">0.019999999552965164</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="def_new_layer_pigment_1_x">
+                    <property name="label">&lt;placeholder - pigment&gt;</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="xalign">0</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">def_new_layer_normal_1_x</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="pigm_brsh_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_right">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compat" comments="Make sure to be consistent w. other occurences of 1.x">Default Pigment Brush Setting:</property>
+                    <property name="ellipsize">middle</property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="pigm_brsh_label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_right">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compat">Default Pigment Brush Setting:</property>
+                    <property name="ellipsize">end</property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">9</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="pigm_brsh_label3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_right">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compat">Default New Layer Type:</property>
+                    <property name="ellipsize">middle</property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">10</property>
+                    <property name="height">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="def_new_layer_normal_2_x">
+                    <property name="label">&lt;placeholder - normal&gt;</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="xalign">0</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">10</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkRadioButton" id="def_new_layer_pigment_2_x">
+                    <property name="label">&lt;placeholder - pigment&gt;</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="xalign">0</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">def_new_layer_normal_2_x</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">11</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="pigment_setting_switch_2_x">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="halign">start</property>
+                    <property name="active">True</property>
+                    <property name="state">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">9</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box7">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkRadioButton" id="compat_1_x_radiobutton">
+                        <property name="label" translatable="yes" context="Prefs Dialog|Compatibility" comments="This refers to a version of MyPaint like 1.0, 1.1, 1.2 etc">1.x</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes" context="Prefs Dialog|Compatibility" comments="Label description for the 1.x compatibility-mode-by-default setting">When creating new documents, use the legacy 1.x compatibility mode by default. In this mode 1.x .ora files will look the same as they did in older versions, but pigment blending will not work well.</property>
+                        <property name="halign">start</property>
+                        <property name="margin_right">24</property>
+                        <property name="xalign">0</property>
+                        <property name="active">True</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="compat_2_x_radiobutton">
+                        <property name="label" translatable="yes" context="Prefs Dialog|Compatibility" comments="This refers to a version of MyPaint like 1.0, 1.1, 1.2 etc">2.x</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="tooltip_text" translatable="yes" context="Prefs Dialog|Compatibility">When creating new documents, use the regular 2.x compatibility mode by default. Old documents will often look different in this mode.</property>
+                        <property name="xalign">0</property>
+                        <property name="draw_indicator">True</property>
+                        <property name="group">compat_1_x_radiobutton</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="compat_file_behavior_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_right">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility" comments="Label to the options of how to handle files which do not have a mode specified (whether they should be opened in 1.x compatibility mode, or 2.x mode)">When Not Specified in File:</property>
+                    <property name="ellipsize">end</property>
+                    <property name="xalign">1</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="compat_file_behavior_combobox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="active">0</property>
+                    <property name="popup_fixed_width">False</property>
+                    <property name="id_column">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="label">
+          <object class="GtkLabel" id="compat_frame_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">&lt;b&gt;Compatibility settings&lt;/b&gt;</property>
+            <property name="use_markup">True</property>
+            <property name="ellipsize">middle</property>
+            <property name="xalign">0</property>
+            <property name="yalign">0</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="position">7</property>
+      </packing>
+    </child>
+    <child type="tab">
+      <object class="GtkLabel" id="compat_label">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes" context="Prefs Dialog|" comments="Tab label in preferences dialog">Compatibility</property>
+      </object>
+      <packing>
+        <property name="position">7</property>
         <property name="tab_fill">False</property>
       </packing>
     </child>

--- a/gui/preferenceswindow.glade
+++ b/gui/preferenceswindow.glade
@@ -1362,15 +1362,16 @@ Different traditions have different color harmonies.</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="row_spacing">12</property>
+                <property name="column_spacing">12</property>
                 <child>
                   <object class="GtkLabel" id="def_compat_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_right">12</property>
-                    <property name="label" translatable="yes">Default Compatibility Mode:</property>
+                    <property name="margin_left">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility">Default Compatibility Mode:</property>
                     <property name="justify">right</property>
                     <property name="ellipsize">end</property>
-                    <property name="xalign">1</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
@@ -1384,7 +1385,7 @@ Different traditions have different color harmonies.</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">2</property>
+                    <property name="top_attach">1</property>
                     <property name="width">2</property>
                   </packing>
                 </child>
@@ -1398,7 +1399,7 @@ Different traditions have different color harmonies.</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">3</property>
+                    <property name="top_attach">2</property>
                     <property name="width">2</property>
                   </packing>
                 </child>
@@ -1412,7 +1413,7 @@ Different traditions have different color harmonies.</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">8</property>
+                    <property name="top_attach">7</property>
                     <property name="width">2</property>
                   </packing>
                 </child>
@@ -1424,7 +1425,7 @@ Different traditions have different color harmonies.</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">7</property>
+                    <property name="top_attach">6</property>
                     <property name="width">2</property>
                   </packing>
                 </child>
@@ -1436,21 +1437,21 @@ Different traditions have different color harmonies.</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">4</property>
+                    <property name="top_attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="pigm_brsh_label1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_right">12</property>
-                    <property name="label" translatable="yes" context="Prefs Dialog|Compat">Default New Layer Type:</property>
+                    <property name="margin_left">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility">Default New Layer Type:</property>
                     <property name="ellipsize">middle</property>
-                    <property name="xalign">1</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">5</property>
+                    <property name="top_attach">4</property>
                     <property name="height">2</property>
                   </packing>
                 </child>
@@ -1466,7 +1467,7 @@ Different traditions have different color harmonies.</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">5</property>
+                    <property name="top_attach">4</property>
                   </packing>
                 </child>
                 <child>
@@ -1482,49 +1483,49 @@ Different traditions have different color harmonies.</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">6</property>
+                    <property name="top_attach">5</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="pigm_brsh_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_right">12</property>
-                    <property name="label" translatable="yes" context="Prefs Dialog|Compat" comments="Make sure to be consistent w. other occurences of 1.x">Default Pigment Brush Setting:</property>
+                    <property name="margin_left">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility">Default Pigment Brush Setting:</property>
                     <property name="ellipsize">middle</property>
-                    <property name="xalign">1</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">4</property>
+                    <property name="top_attach">3</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="pigm_brsh_label2">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_right">12</property>
-                    <property name="label" translatable="yes" context="Prefs Dialog|Compat">Default Pigment Brush Setting:</property>
+                    <property name="margin_left">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility">Default Pigment Brush Setting:</property>
                     <property name="ellipsize">end</property>
-                    <property name="xalign">1</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">9</property>
+                    <property name="top_attach">8</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkLabel" id="pigm_brsh_label3">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_right">12</property>
-                    <property name="label" translatable="yes" context="Prefs Dialog|Compat">Default New Layer Type:</property>
+                    <property name="margin_left">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility">Default New Layer Type:</property>
                     <property name="ellipsize">middle</property>
-                    <property name="xalign">1</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">10</property>
+                    <property name="top_attach">9</property>
                     <property name="height">2</property>
                   </packing>
                 </child>
@@ -1540,7 +1541,7 @@ Different traditions have different color harmonies.</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">10</property>
+                    <property name="top_attach">9</property>
                   </packing>
                 </child>
                 <child>
@@ -1555,7 +1556,7 @@ Different traditions have different color harmonies.</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">11</property>
+                    <property name="top_attach">10</property>
                   </packing>
                 </child>
                 <child>
@@ -1568,7 +1569,7 @@ Different traditions have different color harmonies.</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">9</property>
+                    <property name="top_attach">8</property>
                   </packing>
                 </child>
                 <child>
@@ -1618,30 +1619,104 @@ Different traditions have different color harmonies.</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="compat_file_behavior_label">
+                  <object class="GtkSeparator" id="separator2">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_right">12</property>
-                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility" comments="Label to the options of how to handle files which do not have a mode specified (whether they should be opened in 1.x compatibility mode, or 2.x mode)">When Not Specified in File:</property>
-                    <property name="ellipsize">end</property>
-                    <property name="xalign">1</property>
+                    <property name="valign">start</property>
+                    <property name="margin_top">1</property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
+                    <property name="top_attach">11</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="file_compat_warning_mild">
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility">Show warning for files that may be partially incompatible</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="xalign">0</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">14</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="file_warnings">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility" comments="Label for a set of options">File compatibility warnings:</property>
+                    <property name="ellipsize">middle</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">14</property>
+                    <property name="height">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="file_compat_warning_severe">
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility">Show warning for files that may be fully incompatible</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="xalign">0</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">15</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="compat_file_behavior_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="tooltip_text" translatable="yes" context="Prefs|Compatibility" comments="This is a tooltip for the file behavior options label.">This will only apply to files saved with versions of MyPaint older than 2.0. When you save an OpenRaster file with MyPaint 2.0 or newer the active compatibility mode will be written to the file.</property>
+                    <property name="margin_left">12</property>
+                    <property name="label" translatable="yes" context="Prefs Dialog|Compatibility" comments="Label to the options for how to handle files which do not have a compatibility mode specified (whether they should be opened in 1.x compatibility mode, or 2.x mode)">When Mode is Unspecified:</property>
+                    <property name="ellipsize">end</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">13</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkComboBox" id="compat_file_behavior_combobox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="halign">start</property>
                     <property name="active">0</property>
                     <property name="popup_fixed_width">False</property>
                     <property name="id_column">0</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
+                    <property name="top_attach">13</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="compat_frame_label1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes" context="Prefs|Compatibility" comments="This label indicates a subsection of the compatibility settings related to loading files.">&lt;b&gt;File loading&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                    <property name="ellipsize">middle</property>
+                    <property name="xalign">0</property>
+                    <property name="yalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">12</property>
+                    <property name="width">2</property>
                   </packing>
                 </child>
               </object>

--- a/gui/preferenceswindow.py
+++ b/gui/preferenceswindow.py
@@ -17,6 +17,7 @@ from gettext import gettext as _
 
 from gi.repository import Gtk
 
+from gui.compatibility import CompatibilityPreferences
 import lib.config
 import lib.localecodes
 from lib.i18n import USER_LOCALE_PREF
@@ -61,6 +62,7 @@ class PreferencesWindow (windowing.Dialog):
         self._builder = builder
 
         getobj = builder.get_object
+        self.compat_preferences = CompatibilityPreferences(app, builder)
 
         # Populate locale/language combo box
         locale_combo = getobj("locale_combobox")
@@ -215,6 +217,8 @@ class PreferencesWindow (windowing.Dialog):
         autosave_interval_adj = getobj("autosave_interval_adjustment")
         autosave_interval_adj.set_value(autosave_interval)
         self._autosave_interval_spinbutton.set_sensitive(autosave)
+
+        self.compat_preferences.update_ui()
 
         self.in_update_ui = False
 

--- a/gui/userconfig.py
+++ b/gui/userconfig.py
@@ -16,7 +16,7 @@ import logging
 from gi.repository import GLib
 
 import lib.glib
-
+from lib.eotf import DEFAULT_EOTF
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ def default_configuration():
         'document.autosave_interval': 10,
 
         # configurable EOTF.  Set to 1.0 for legacy non-linear behaviour
-        'display.colorspace_EOTF': 2.2,
+        'display.colorspace_EOTF': DEFAULT_EOTF,
         'display.colorspace': "srgb",
         # sRGB is a good default even for OS X since v10.6 / Snow
         # Leopard: http://support.apple.com/en-us/HT3712.

--- a/gui/userconfig.py
+++ b/gui/userconfig.py
@@ -17,6 +17,7 @@ from gi.repository import GLib
 
 import lib.glib
 from lib.eotf import DEFAULT_EOTF
+from gui.compatibility import DEFAULT_CONFIG as COMPAT_CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +128,7 @@ def default_configuration():
             'Button3': 'ShowPopupMenu',
         },
     }
+    default_config.update(COMPAT_CONFIG)
     if sys.platform == 'win32':
         # The Linux wacom driver inverts the button numbers of the
         # pen flip button, because middle-click is the more useful

--- a/lib/brush.py
+++ b/lib/brush.py
@@ -16,6 +16,7 @@ import json
 from lib import mypaintlib
 from lib import helpers
 from lib import brushsettings
+from lib.eotf import eotf
 from lib.pycompat import unicode
 from lib.pycompat import PY3
 
@@ -203,12 +204,6 @@ class BrushInfo (object):
         self.pending_updates = set()
         if string:
             self.load_from_string(string)
-        from gui.application import get_app
-        self.app = get_app()
-        try:
-            self.EOTF = self.app.preferences['display.colorspace_EOTF']
-        except: 
-            self.EOTF = 2.2
 
     def settings_changed_cb(self, settings):
         self.cache_str = None
@@ -532,7 +527,7 @@ class BrushInfo (object):
                 f(pending)
 
     def get_color_hsv(self):
-        tf = self.EOTF
+        tf = eotf()
         h = self.get_base_value('color_h')
         s = self.get_base_value('color_s')
         v = self.get_base_value('color_v')
@@ -544,7 +539,7 @@ class BrushInfo (object):
         return (h, s, v)
 
     def set_color_hsv(self, hsv):
-        tf = self.EOTF
+        tf = eotf()
         if not hsv:
             return
         self.begin_atomic()

--- a/lib/brush.py
+++ b/lib/brush.py
@@ -191,12 +191,20 @@ class BrushInfo (object):
     """Fully parsed description of a brush.
     """
 
-    def __init__(self, string=None):
-        """Construct a BrushInfo object, optionally parsing it."""
+    def __init__(self, string=None, default_overrides=None):
+        """Construct a BrushInfo object, optionally parsing it.
+
+        :param string: optional json string to load info from
+        :param default_overrides: optional dict of
+        "canonical setting name -> (BrushSettingInfo -> value)" mappings,
+        each used to change the default values of a settings.
+        """
         super(BrushInfo, self).__init__()
         self.settings = {}
+        self.undefined_settings = set()
         self.cache_str = None
         self.observers = []
+        self.default_overrides = default_overrides
         for s in brushsettings.settings:
             self.reset_setting(s.cname)
         self.observers.append(self.settings_changed_cb)
@@ -217,6 +225,8 @@ class BrushInfo (object):
     def load_from_brushinfo(self, other):
         """Updates the brush's Settings from (a clone of) ``brushinfo``."""
         self.settings = copy.deepcopy(other.settings)
+        self.default_overrides = other.default_overrides
+        self.undefined_settings = set(other.undefined_settings)
         for f in self.observers:
             f(ALL_SETTINGS)
         self.cache_str = other.cache_str
@@ -230,7 +240,13 @@ class BrushInfo (object):
         self.end_atomic()
 
     def reset_setting(self, cname):
-        basevalue = brushsettings.settings_dict[cname].default
+        s = brushsettings.settings_dict[cname]
+        if self.default_overrides and cname in self.default_overrides:
+            override = self.default_overrides[cname]
+            basevalue = override(s)
+        else:
+            basevalue = s.default
+
         if cname == 'opaque_multiply':
             # make opaque depend on pressure by default
             input_points = {'pressure': [(0.0, 0.0), (1.0, 1.0)]}
@@ -239,6 +255,10 @@ class BrushInfo (object):
         self.settings[cname] = [basevalue, input_points]
         for f in self.observers:
             f(set([cname]))
+
+    def reset_if_undefined(self, cname):
+        if cname in self.undefined_settings:
+            self.reset_setting(cname)
 
     def to_json(self):
         settings = dict(self.settings)
@@ -305,6 +325,10 @@ class BrushInfo (object):
         # settings not in json_string must still be present in self.settings
         self.load_defaults()
 
+        # settings not defined in the json
+        self.undefined_settings = BRUSH_SETTINGS.difference(
+            set(brush_def['settings'].keys())
+        )
         # MyPaint expects that each setting has an array, where
         # index 0 is base value, and index 1 is inputs
         for k, v in brush_def['settings'].items():
@@ -402,6 +426,7 @@ class BrushInfo (object):
         # but still use non-zero default
         self.settings['anti_aliasing'][0] = 0.0
         num_parsed = 0
+        settings_loaded = set()
         for rawcname, rawvalue in rawsettings:
             try:
                 cnamevaluepairs = _oldfmt_parse_value(
@@ -416,6 +441,7 @@ class BrushInfo (object):
                         if func:
                             value = _oldfmt_transform_y(value, func)
                     self.settings[cname] = value
+                    settings_loaded.add(cname)
             except Exception as e:
                 line = "%s %s" % (rawcname, rawvalue)
                 errors.append((line, str(e)))
@@ -427,6 +453,7 @@ class BrushInfo (object):
                 "old brush file format parser did not find "
                 "any brush settings in this file",
             )
+        self.undefined_settings = BRUSH_SETTINGS.difference(settings_loaded)
 
     def save_to_string(self):
         """Serialise brush information to a string. Result is cached."""
@@ -452,12 +479,16 @@ class BrushInfo (object):
         assert not math.isnan(value)
         assert not math.isinf(value)
         if self.settings[cname][0] != value:
+            if cname in self.undefined_settings:
+                self.undefined_settings.remove(cname)
             self.settings[cname][0] = value
             for f in self.observers:
                 f(set([cname]))
 
     def set_points(self, cname, input, points):
         assert cname in BRUSH_SETTINGS
+        if cname in self.undefined_settings:
+            self.undefined_settings.remove(cname)
         points = tuple(points)
         d = self.settings[cname][1]
         if points:
@@ -470,6 +501,8 @@ class BrushInfo (object):
 
     def set_setting(self, cname, value):
         self.settings[cname] = copy.deepcopy(value)
+        if cname in self.undefined_settings:
+            self.undefined_settings.remove(cname)
         for f in self.observers:
             f(set([cname]))
 

--- a/lib/brush.py
+++ b/lib/brush.py
@@ -345,6 +345,22 @@ class BrushInfo (object):
         # FIXME: Brush groups are stored externally in order.conf,
         # FIXME: is that one redundant?
 
+    @staticmethod
+    def brush_string_inverted_eotf(brush_string):
+        try:
+            brush = json.loads(brush_string)
+            bsett = brush['settings']
+            k = 'base_value'
+            hsv = bsett['color_h'][k], bsett['color_s'][k], bsett['color_v'][k]
+            h, s, v = helpers.transform_hsv(hsv, 1.0 / 2.2)
+            bsett['color_h'][k] = h
+            bsett['color_s'][k] = s
+            bsett['color_v'][k] = v
+            return json.dumps(brush)
+        except Exception:
+            logger.exception("Failed to invert color in brush string")
+            return brush_string
+
     def load_from_string(self, settings_str):
         """Load a setting string, overwriting all current settings."""
 

--- a/lib/document.py
+++ b/lib/document.py
@@ -92,6 +92,10 @@ _ORA_UNSAVED_PAINTING_TIME_ATTR \
 _ORA_JSON_SETTINGS_ATTR \
     = "{%s}json-settings" % (lib.xml.OPENRASTER_MYPAINT_NS,)
 
+_ORA_EOTF_ATTR \
+    = "{%s}eotf" % (lib.xml.OPENRASTER_MYPAINT_NS,)
+
+
 _ORA_JSON_SETTINGS_ZIP_PATH = "data/mypaint-settings.json"
 
 ## Class defs
@@ -630,6 +634,7 @@ class Document (object):
         image_elem = ET.Element('image')
         image_elem.attrib['w'] = str(w0)
         image_elem.attrib['h'] = str(h0)
+        image_elem.attrib[_ORA_EOTF_ATTR] = str(lib.eotf.eotf())
         frame_active_value = ("true" if self.frame_enabled else "false")
         image_elem.attrib[_ORA_FRAME_ACTIVE_ATTR] = frame_active_value
         image_elem.append(root_elem)
@@ -1792,6 +1797,11 @@ class Document (object):
         image_xres = max(0, int(image_elem.attrib.get('xres', 0)))
         image_yres = max(0, int(image_elem.attrib.get('yres', 0)))
 
+        # Determine which compatibility mode the file should be opened with
+        if 'compat_handler' in kwargs:
+            eotf = image_elem.attrib.get(_ORA_EOTF_ATTR, None)
+            kwargs['compat_handler'](eotf, root_stack_elem)
+
         # Delegate loading of image data to the layers tree itself
         self.layer_stack.load_from_openraster(
             orazip,
@@ -2043,6 +2053,7 @@ def _save_layers_to_new_orazip(root_stack, filename, bbox=None,
     x0, y0, w0, h0 = bbox
     image.attrib['w'] = str(w0)
     image.attrib['h'] = str(h0)
+    image.attrib[_ORA_EOTF_ATTR] = str(lib.eotf.eotf())
     root_stack_path = ()
     root_stack_elem = root_stack.save_to_openraster(
         orazip, tempdir, root_stack_path,

--- a/lib/document.py
+++ b/lib/document.py
@@ -1821,8 +1821,8 @@ class Document (object):
         image_yres = max(0, int(image_elem.attrib.get('yres', 0)))
 
         # Determine which compatibility mode the file should be opened with
+        eotf = image_elem.attrib.get(_ORA_EOTF_ATTR, None)
         if 'compat_handler' in kwargs:
-            eotf = image_elem.attrib.get(_ORA_EOTF_ATTR, None)
             kwargs['compat_handler'](eotf, root_stack_elem)
 
         # Delegate loading of image data to the layers tree itself
@@ -1832,6 +1832,7 @@ class Document (object):
             cache_dir,
             progress,
             x=0, y=0,
+            invert_strokemaps=(eotf is None),
             **kwargs
         )
         assert len(self.layer_stack) > 0

--- a/lib/eotf.py
+++ b/lib/eotf.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2019 by the MyPaint Development Team.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+"""A configurable eotf value
+"""
+
+# Overall, this is a bit ugly, but due to the number of call chains
+# that would need to be updated with the same copy-pasted code, this
+# is still probably the best we can do as a post-fix, since nothing
+# was built around using an eotf to begin with.
+
+DEFAULT_EOTF = 2.2
+__EOTF = dict()
+
+
+# Value used to transform color channels on
+# load/save and other color operations.
+
+def set_eotf(value):
+    """Set the EOTF value to be used for color transforms"""
+    assert isinstance(value, float)
+    __EOTF['current'] = value
+
+
+def eotf():
+    """Get the current EOTF value, used for color transforms"""
+    return __EOTF.get('current', DEFAULT_EOTF)
+
+
+# Session-constant base EOTF - the one to fall back to
+# when inverting already applied color transforms.
+
+def set_base_eotf(value):
+    """Set the base EOTF value used to invert transforms"""
+    assert isinstance(value, float)
+    __EOTF['base'] = value
+
+
+def base_eotf():
+    """Get the base eotf, configured in the user preferences"""
+    return __EOTF.get('base', DEFAULT_EOTF)

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -487,6 +487,11 @@ def hsv_to_rgb(h, s, v):
     return colorsys.hsv_to_rgb(h, s, v)
 
 
+def transform_hsv(hsv, eotf):
+    r, g, b = hsv_to_rgb(*hsv)
+    return rgb_to_hsv(r**eotf, g**eotf, b**eotf)
+
+
 def zipfile_writestr(z, arcname, data):
     """Write a string into a zipfile entry, with standard permissions
 

--- a/lib/layer/core.py
+++ b/lib/layer/core.py
@@ -29,10 +29,10 @@ import lib.fileutils
 import lib.pixbuf
 from lib.modes import PASS_THROUGH_MODE
 from lib.modes import STANDARD_MODES
-from lib.modes import DEFAULT_MODE
 from lib.modes import ORA_MODES_BY_OPNAME
 from lib.modes import MODES_EFFECTIVE_AT_ZERO_ALPHA
 from lib.modes import MODES_DECREASING_BACKDROP_ALPHA
+import lib.modes
 import lib.xml
 import lib.tiledsurface
 from .rendering import Renderable
@@ -70,7 +70,6 @@ class LayerBase (Renderable):
     TYPE_DESCRIPTION = None
 
     PERMITTED_MODES = set(STANDARD_MODES)
-    INITIAL_MODE = DEFAULT_MODE
 
     ## Construction, loading, other lifecycle stuff
 
@@ -89,7 +88,7 @@ class LayerBase (Renderable):
         self._name = name
         self._visible = True
         self._locked = False
-        self._mode = self.INITIAL_MODE
+        self._mode = lib.modes.default_mode()
         self._group_ref = None
         self._root_ref = None
         self._thumbnail = None
@@ -176,7 +175,7 @@ class LayerBase (Renderable):
         attrs = elem.attrib
         self.name = unicode(attrs.get('name', ''))
         compop = str(attrs.get('composite-op', ''))
-        self.mode = ORA_MODES_BY_OPNAME.get(compop, DEFAULT_MODE)
+        self.mode = ORA_MODES_BY_OPNAME.get(compop, lib.modes.default_mode())
         self.opacity = helpers.clamp(float(attrs.get('opacity', '1.0')),
                                      0.0, 1.0)
         visible = attrs.get('visibility', 'visible').lower()
@@ -481,7 +480,7 @@ class LayerBase (Renderable):
     def mode(self, mode):
         mode = int(mode)
         if mode not in self.PERMITTED_MODES:
-            mode = DEFAULT_MODE
+            mode = lib.modes.default_mode()
         if mode == self._mode:
             return
         # Forcing the opacity for layer groups here allows a redraw to

--- a/lib/layer/data.py
+++ b/lib/layer/data.py
@@ -350,7 +350,7 @@ class SurfaceBackedLayer (core.LayerBase, lib.autosave.Autosaveable):
             if self not in spec.layers:
                 return []
 
-        mode_default = lib.modes.DEFAULT_MODE
+        mode_default = lib.modes.default_mode()
         if spec.previewing:
             mode = mode_default
             opacity = 1.0
@@ -1385,7 +1385,7 @@ class SimplePaintingLayer (SurfaceBackedLayer):
         return split
 
     @contextlib.contextmanager
-    def cairo_request(self, x, y, w, h, mode=lib.modes.DEFAULT_MODE):
+    def cairo_request(self, x, y, w, h, mode=lib.modes.default_mode):
         """Get a Cairo context for a given area, then put back changes.
 
         See lib.tiledsurface.MyPaintSurface.cairo_request() for details.

--- a/lib/layer/data.py
+++ b/lib/layer/data.py
@@ -1423,12 +1423,13 @@ class StrokemappedPaintingLayer (SimplePaintingLayer):
 
     # The un-namespaced legacy attribute name is deprecated since
     # MyPaint v1.2.0, and painting layers in OpenRaster files will not
-    # be saved with it beginning with v1.3.0 at the earliest.
+    # be saved with it beginning with v2.0.0.
     # MyPaint will support reading .ora files using the legacy strokemap
     # attribute (and the "v2" strokemap format, if the format changes)
-    # until v2.0.0.
+    # throughout v2.x.
 
     _ORA_STROKEMAP_ATTR = "{%s}strokemap" % (lib.xml.OPENRASTER_MYPAINT_NS,)
+    _ORA_STROKEMAP_LEGACY_ATTR = "mypaint_strokemap_v2"
 
     ## Initializing & resetting
 
@@ -1484,6 +1485,7 @@ class StrokemappedPaintingLayer (SimplePaintingLayer):
         y += int(attrs.get('y', 0))
         supported_strokemap_attrs = [
             self._ORA_STROKEMAP_ATTR,
+            self._ORA_STROKEMAP_LEGACY_ATTR,
         ]
         strokemap_name = None
         for attr_qname in supported_strokemap_attrs:

--- a/lib/layer/group.py
+++ b/lib/layer/group.py
@@ -19,11 +19,9 @@ from copy import copy
 
 from lib.gettext import C_
 import lib.mypaintlib
-import lib.tiledsurface as tiledsurface
 import lib.pixbufsurface
 import lib.helpers as helpers
 import lib.fileutils
-from lib.modes import DEFAULT_MODE
 from lib.modes import STANDARD_MODES
 from lib.modes import STACK_MODES
 from lib.modes import PASS_THROUGH_MODE
@@ -75,7 +73,6 @@ class LayerStack (core.LayerBase, lib.autosave.Autosaveable):
     )
 
     PERMITTED_MODES = set(STANDARD_MODES + STACK_MODES)
-    INITIAL_MODE = lib.mypaintlib.CombineSpectralWGM
 
     ## Construction and other lifecycle stuff
 
@@ -125,7 +122,8 @@ class LayerStack (core.LayerBase, lib.autosave.Autosaveable):
         # under the OpenRaster and W3C definition. Represented
         # internally with a special mode to make the UI prettier.
         isolated_flag = unicode(elem.attrib.get("isolation", "auto"))
-        is_pass_through = (self.mode == DEFAULT_MODE
+        # TODO: Check if this applies to CombineSpectralWGM as well
+        is_pass_through = (self.mode == lib.mypaintlib.CombineNormal
                            and self.opacity == 1.0
                            and (isolated_flag.lower() == "auto"))
         if is_pass_through:
@@ -181,7 +179,8 @@ class LayerStack (core.LayerBase, lib.autosave.Autosaveable):
         y += int(elem.attrib.get("y", 0))
         # Convert normal+nonisolated to the internal pass-thru mode
         isolated_flag = unicode(elem.attrib.get("isolation", "auto"))
-        is_pass_through = (self.mode == DEFAULT_MODE
+        # TODO: Check if this applies to CombineSpectralWGM as well
+        is_pass_through = (self.mode == lib.mypaintlib.CombineNormal
                            and self.opacity == 1.0
                            and (isolated_flag.lower() == "auto"))
         if is_pass_through:

--- a/lib/layer/tree.py
+++ b/lib/layer/tree.py
@@ -27,6 +27,7 @@ from gi.repository import GdkPixbuf
 from gi.repository import GLib
 import numpy as np
 
+from lib.eotf import eotf
 from lib.gettext import C_
 import lib.mypaintlib
 import lib.tiledsurface as tiledsurface
@@ -125,12 +126,6 @@ class RootLayerStack (group.LayerStack):
         """
         super(RootLayerStack, self).__init__(**kwargs)
         self.doc = doc
-        from gui.application import get_app
-        self.app = get_app()
-        try:
-            self.EOTF = self.app.preferences['display.colorspace_EOTF']
-        except: 
-            self.EOTF = 2.2
         self._render_cache = lib.cache.LRUCache(capacity=cache_size)
         # Background
         default_bg = (255, 255, 255)
@@ -530,7 +525,7 @@ class RootLayerStack (group.LayerStack):
                         conv = lib.mypaintlib.tile_convert_rgba16_to_rgba8
                     else:
                         conv = lib.mypaintlib.tile_convert_rgbu16_to_rgbu8
-                    conv(dst, dst_8bpc_orig, self.EOTF)
+                    conv(dst, dst_8bpc_orig, eotf())
 
                     if use_cache:
                         self._render_cache_set(key1, key2, dst_8bpc_orig)
@@ -700,7 +695,7 @@ class RootLayerStack (group.LayerStack):
                 conv = lib.mypaintlib.tile_convert_rgba16_to_rgba8
             else:
                 conv = lib.mypaintlib.tile_convert_rgbu16_to_rgbu8
-            conv(dst, dst_8bpc_orig, self.EOTF)
+            conv(dst, dst_8bpc_orig, eotf())
             dst = dst_8bpc_orig
 
     def _validate_layer_bbox_arg(self, layer, bbox,
@@ -2796,7 +2791,7 @@ class _TileRenderWrapper (TileAccessible, TileBlittable):
                 conv = lib.mypaintlib.tile_convert_rgba16_to_rgba8
             else:
                 conv = lib.mypaintlib.tile_convert_rgbu16_to_rgbu8
-            conv(src, dst, self.EOTF)
+            conv(src, dst, eotf())
 
     def __getattr__(self, attr):
         """Pass through calls to other methods"""

--- a/lib/layer/tree.py
+++ b/lib/layer/tree.py
@@ -37,7 +37,6 @@ import lib.helpers as helpers
 from lib.observable import event
 import lib.pixbuf
 import lib.cache
-from lib.modes import DEFAULT_MODE
 from lib.modes import PASS_THROUGH_MODE
 from lib.modes import MODES_DECREASING_BACKDROP_ALPHA
 from . import data

--- a/lib/meta.py
+++ b/lib/meta.py
@@ -170,6 +170,12 @@ class Compatibility:
     # app minor version >= file minor version
     FULLY = 3
 
+    DESC = {
+        INCOMPATIBLE: 'incompatible',
+        PARTIALLY: 'only partially compatible',
+        FULLY: 'compatible',
+    }
+
 
 def compatibility(target_version_string):
     """ Check if the current version is compatible

--- a/lib/modes.py
+++ b/lib/modes.py
@@ -13,14 +13,9 @@ from __future__ import division, print_function
 from gettext import gettext as _
 import lib.mypaintlib
 
-
 #: Additional pass-through mode for layer groups (not saved, but reflected
 #: into other flags which are saved)
 PASS_THROUGH_MODE = -1
-
-
-#: The default layer combine mode
-DEFAULT_MODE = lib.mypaintlib.CombineSpectralWGM
 
 
 #: Valid modes for all layers
@@ -31,13 +26,26 @@ STANDARD_MODES = tuple(range(lib.mypaintlib.NumCombineModes))
 STACK_MODES = (PASS_THROUGH_MODE,)
 
 
+#: The default layer combine mode - overrideable
+_DEFAULT_MODE = lib.mypaintlib.CombineSpectralWGM
+
+
+def set_default_mode(mode):
+    assert mode in STANDARD_MODES
+    global _DEFAULT_MODE
+    _DEFAULT_MODE = mode
+
+
+def default_mode():
+    return _DEFAULT_MODE
+
+
 #: UI strings (label, tooltip) for the layer modes
 MODE_STRINGS = {
     # Group modes
     PASS_THROUGH_MODE: (
         _("Pass-through"),
-        _("Group contents apply directly to the group's backdrop"),
-        ),
+        _("Group contents apply directly to the group's backdrop")),
     # Standard blend modes (using src-over compositing)
     lib.mypaintlib.CombineNormal: (
         _("Normal"),
@@ -156,5 +164,7 @@ MODES_EFFECTIVE_AT_ZERO_ALPHA = {
 #: if their own alpha is zero.
 MODES_CLEARING_BACKDROP_AT_ZERO_ALPHA = {
     m for m in range(lib.mypaintlib.NumCombineModes)
-    if lib.mypaintlib.combine_mode_get_info(m).get("zero_alpha_clears_backdrop")
+    if lib.mypaintlib.combine_mode_get_info(m).get(
+        "zero_alpha_clears_backdrop"
+    )
 }

--- a/lib/pixbufsurface.py
+++ b/lib/pixbufsurface.py
@@ -20,6 +20,7 @@ import cairo
 
 from . import mypaintlib
 from . import helpers
+from lib.eotf import eotf
 import lib.surface
 from lib.surface import TileAccessible, TileBlittable
 from lib.errors import AllocationError
@@ -72,15 +73,7 @@ class Surface (TileAccessible, TileBlittable):
 
         self.ew = tw * N
         self.eh = th * N
-        
-        from gui.application import get_app
-        self.app = get_app()
-        try:
-            self.EOTF = self.app.preferences['display.colorspace_EOTF']
-        except: 
-            self.EOTF = 2.2
 
-        # OPTIMIZE: remove assertions here?
         assert self.ew >= w and self.eh >= h
         assert self.ex <= x and self.ey <= y
 
@@ -165,7 +158,7 @@ class Surface (TileAccessible, TileBlittable):
         assert dst.dtype == 'uint16', '16 bit dst expected'
         src = self.tile_memory_dict[(tx, ty)]
         assert src.shape[2] == 4, 'alpha required'
-        mypaintlib.tile_convert_rgba8_to_rgba16(src, dst, self.EOTF)
+        mypaintlib.tile_convert_rgba8_to_rgba16(src, dst, eotf())
 
     @contextlib.contextmanager
     def cairo_request(self):

--- a/lib/tiledsurface.py
+++ b/lib/tiledsurface.py
@@ -22,7 +22,6 @@ from gettext import gettext as _
 import numpy as np
 
 from . import mypaintlib
-from . import helpers
 from . import pixbufsurface
 from lib.eotf import eotf
 import lib.surface
@@ -731,7 +730,7 @@ class MyPaintSurface (TileAccessible, TileBlittable, TileCompositable):
         return flood_fill(self, fill_args, dst)
 
     @contextlib.contextmanager
-    def cairo_request(self, x, y, w, h, mode=lib.modes.DEFAULT_MODE):
+    def cairo_request(self, x, y, w, h, mode=lib.modes.default_mode):
         """Get a Cairo context for a given area, then put back changes.
 
         :param int x: Request area's X coordinate.
@@ -791,6 +790,9 @@ class MyPaintSurface (TileAccessible, TileBlittable, TileCompositable):
         """
 
         # Normalize and validate args
+        if callable(mode):
+            mode = mode()
+
         if mode is not None:
             if mode == lib.modes.PASS_THROUGH_MODE:
                 mode = None


### PR DESCRIPTION
This adds support for the 1.x rendering and default settings, allowing pre-2.x files to be rendered consistently, albeit with worse support for the pigment features.

The compatibility mode for a document is written to the openraster file using a namespaced attribute, and can be changed by explicitly selecting a compatibility mode to open a file with (dropdown menu in file chooser dialog).

The commit messages describe the details quite comprehensively.

The majority of the new (non-glade) code is placed in the new gui.compatibility module, to avoid littering the existing modules with code that's only relevant to supporting old behavior.