### PR TITLE
Add OARS rating to appdata

### DIFF
--- a/desktop/mypaint.appdata.xml
+++ b/desktop/mypaint.appdata.xml
@@ -29,5 +29,6 @@
       <image>https://cloud.githubusercontent.com/assets/1840562/8720135/b28edc2e-2b65-11e5-91ce-9d557bcd2c9e.png</image>
     </screenshot>
   </screenshots>
+  <content_rating type="oars-1.1" />
   <update_contact>mypaintopensource@gmail.com</update_contact>
 </component>


### PR DESCRIPTION
OARS is used by software stores to classify apps https://hughsie.github.io/oars/ this patch helps with a flathub requirement but is useful everywhere that appdata is used.