### PR TITLE
Fix misc. documentation and source comment typos

### DIFF
--- a/gui/buttonmap.py
+++ b/gui/buttonmap.py
@@ -209,7 +209,7 @@ class ButtonMapping (object):
             # Exclude possible bindings whose modifiers do not overlap
             if (modifiers & possible) != modifiers:
                 continue
-            # Include only exact matches, and those possibilies which can be
+            # Include only exact matches, and those possibilities which can be
             # reached by pressing more modifier keys.
             if modifiers == possible or ~modifiers & possible:
                 possibilities.append((possible, btn, action))

--- a/gui/resources.xml
+++ b/gui/resources.xml
@@ -23,7 +23,7 @@ General
 Labels
 
   * Typically <verb> [<target>]
-  * Title case, imperitive mood "Open Brush…", "New Curve", etc.
+  * Title case, imperative mood "Open Brush…", "New Curve", etc.
   - No trailing full stop.
   - Trailing ellipsis if immediate user input is needed to complete the action.
   - If the object of the action is the main canvas, omit the target

--- a/gui/tileddrawwidget.py
+++ b/gui/tileddrawwidget.py
@@ -836,7 +836,7 @@ class CanvasRenderer (Gtk.DrawingArea, DrawCursorMixin):
     def _state_changed_cb(self, widget, oldstate):
         """Handle the sensitivity state changing
 
-        Saving and loading images toggles the sensitivty state on all
+        Saving and loading images toggles the sensitivity state on all
         toplevel windows. This causes a state shift on the TDW too.
         While the TDW is insensitive, its cursor is updated to respect
         the toplevel's cursor (typically a watch or an hourglass or

--- a/lib/color.py
+++ b/lib/color.py
@@ -637,7 +637,7 @@ class YCbCrColor (UIColor):
     tilted regular hexagon.
 
     This color space is derived from the displayable RGB space. The luma or
-    chroma components may be manipluated, but because the envelope of the RGB
+    chroma components may be manipulated, but because the envelope of the RGB
     cube does not align with this space's axes it's quite easy to go out of
     the displayable gamut.
 

--- a/lib/modes.py
+++ b/lib/modes.py
@@ -26,7 +26,7 @@ STANDARD_MODES = tuple(range(lib.mypaintlib.NumCombineModes))
 STACK_MODES = (PASS_THROUGH_MODE,)
 
 
-#: The default layer combine mode - overrideable
+#: The default layer combine mode - overridable
 _DEFAULT_MODE = lib.mypaintlib.CombineSpectralWGM
 
 

--- a/po/README.md
+++ b/po/README.md
@@ -239,7 +239,7 @@ Weblate provides a browser-based interface for adding, editing
 and updating translations. It's a very good way to provide
 translations without having to worry about the technical details.
 
-If you are interested in keeping the transalations up to date,
+If you are interested in keeping the translations up to date,
 please subscribe to the MyPaint project on WebLate:
 <https://hosted.weblate.org/accounts/profile/#subscriptions>.
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from setuptools.command.install_scripts import install_scripts
 
 
 # Some versions of clang requires different flag configurations than gcc
-# to link correctly, so we enable configuration via environemnt variables.
+# to link correctly, so we enable configuration via environment variables.
 OPENMP_CFLAG = os.getenv("OPENMP_CFLAG", "-fopenmp")
 OPENMP_LDFLAG = os.getenv("OPENMP_LDFLAG", "-fopenmp")
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po -L ba,daa,hist,lod,od`