### PR TITLE
Define _DARWIN_C_SOURCE on Darwin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -874,7 +874,7 @@ def get_ext_modules():
     extra_link_args = []
 
     if sys.platform == "darwin":
-        pass
+        extra_compile_args.append('-D_DARWIN_C_SOURCE')
     elif sys.platform == "win32":
         pass
     elif sys.platform == "msys":


### PR DESCRIPTION
Since we are already defining `_POSIX_C_SOURCE`, also define `_DARWIN_C_SOURCE` on Darwin to avoid a build error.

Closes #1086