### PR TITLE
Fix hound config [skip travis] [skip appveyor]

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,21 @@
+[flake8]
+ignore = E266,W503,E251,E226,BLK100
+exclude =
+    .git,
+    __pycache__,
+    docs,
+    build,
+    dist,
+    out,
+    svg,
+    pixmaps,
+    backgrounds,
+    desktop,
+    tests,
+    glade,
+    flatpak,
+    appimage,
+    palettes,
+    lib/mypaintlib.py,
+    po
+max-complexity = 20

--- a/.hound.yml
+++ b/.hound.yml
@@ -5,6 +5,6 @@
 
 fail_on_violations: true
 
-python:
+flake8:
   enabled: true
   config_file: setup.cfg

--- a/gui/application.py
+++ b/gui/application.py
@@ -202,7 +202,7 @@ class Application (object):
     """
 
     #: Singleton instance
-    _INSTANCE = None
+    _INSTANCE = None  # TMPTMPTMPTMP
 
     def __init__(self, filenames, state_dirs, version, fullscreen=False):
         """Construct, but do not run.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,15 +25,20 @@ exclude =
     .git,
     __pycache__,
     docs,
-    build, dist,
+    build,
+    dist,
     out,
-    svg, pixmaps, backgrounds, desktop,
-    tests, glade,
-    flatpak, appimage
-    brushes, palettes,
-    debian,
-    po,
-    lib/mypaintlib.py
+    svg,
+    pixmaps,
+    backgrounds,
+    desktop,
+    tests,
+    glade,
+    flatpak,
+    appimage,
+    palettes,
+    lib/mypaintlib.py,
+    po
 max-complexity = 20
 
 [pep8]


### PR DESCRIPTION
Duplication is not nice, so the current flake8 config in `setup.cfg` should prob. be removed.