### PR TITLE
Remove reference to non-existent Gdk.EventGrabBroken time attribute

### DIFF
--- a/gui/picker.py
+++ b/gui/picker.py
@@ -360,7 +360,7 @@ class PickingGrabPresenter (object):
 
     def _in_grab_grab_broken_cb(self, widget, event):
         logger.debug("Grab broken, cleaning up.")
-        self._ungrab_grabbed_devices(time=event.time)
+        self._ungrab_grabbed_devices()
         return False
 
     def _end_grab(self, event):


### PR DESCRIPTION
PyGTK Gdk.EventGrabBroken maps to the GdkEventGrabBroken struct which
does not have a time attribute. The invalid attribute was being passed
as an argument that had an appropriate default value, so the attribute
reference was removed, enabling the default value to be used instead.

Closes mypaint/mypaint#899