### PR TITLE
fix dimming of main window after dismissing recover backup window

### DIFF
--- a/gui/autorecover.py
+++ b/gui/autorecover.py
@@ -161,7 +161,6 @@ class Presenter (object):
                     else:
                         doc.reset_view(True, True, True)
         finally:
-            self._dialog.set_transient_for(None)
             self._dialog.hide()
         # If an error was detected, tell the user about it.
         # They'll be given a new working doc & cache automatically.


### PR DESCRIPTION
Problem was described by calsioro on community forum: https://community.mypaint.org/t/main-window-stays-dim-after-dismising-the-recover-backup-window/2573