### PR TITLE
docs: fix simple typo, retrieveing -> retrieving

### DIFF
--- a/svg/symbolic-icons-extract.py
+++ b/svg/symbolic-icons-extract.py
@@ -73,7 +73,7 @@ class FakeOptions:
 
 
 def get_by_attrib(parent, pred):
-    """Utility function for retrieveing child elements by attribute predicates
+    """Utility function for retrieving child elements by attribute predicates
     """
     return [c for c in parent.getchildren() if pred(c.attrib)]
 


### PR DESCRIPTION
There is a small typo in svg/symbolic-icons-extract.py.

Should read `retrieving` rather than `retrieveing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md