### PR TITLE
python: fix for Python 3.11

### DIFF
--- a/lib/gettext_setup.py
+++ b/lib/gettext_setup.py
@@ -82,13 +82,11 @@ def init_gettext(localepath):
     # yanked in over GI.
     # https://bugzilla.gnome.org/show_bug.cgi?id=574520#c26
     bindtextdomain = None
-    bind_textdomain_codeset = None
     textdomain = None
 
     # Try the POSIX/Linux way first.
     try:
         bindtextdomain = locale.bindtextdomain
-        bind_textdomain_codeset = locale.bind_textdomain_codeset
         textdomain = locale.textdomain
     except AttributeError:
         logger.warning(
@@ -117,12 +115,6 @@ def init_gettext(localepath):
                         ctypes.c_char_p,
                     )
                     bindtextdomain.restype = ctypes.c_char_p
-                    bind_textdomain_codeset = libintl.bind_textdomain_codeset
-                    bind_textdomain_codeset.argtypes = (
-                        ctypes.c_char_p,
-                        ctypes.c_char_p,
-                    )
-                    bind_textdomain_codeset.restype = ctypes.c_char_p
                     textdomain = libintl.textdomain
                     textdomain.argtypes = (
                         ctypes.c_char_p,
@@ -177,35 +169,22 @@ def init_gettext(localepath):
         # complete set from the same source.
         # Required for translatable strings in GtkBuilder XML
         # to be translated.
-        if bindtextdomain and bind_textdomain_codeset and textdomain:
+        if bindtextdomain and textdomain:
             assert os.path.exists(path)
             assert os.path.isdir(path)
             if sys.platform == 'win32':
                 p = bindtextdomain(dom.encode('utf-8'), path.encode('utf-8'))
-                c = bind_textdomain_codeset(
-                    dom.encode('utf-8'), codeset.encode('utf-8')
-                )
             else:
                 p = bindtextdomain(dom, path)
-                c = bind_textdomain_codeset(dom, codeset)
             logger.debug("C bindtextdomain(%r, %r): %r", dom, path, p)
-            logger.debug(
-                "C bind_textdomain_codeset(%r, %r): %r",
-                dom, codeset, c,
-            )
         # Call the implementations in Python's standard gettext module
         # too.  This has proper cross-platform support, but it only
         # initializes the native Python "gettext" module.
         # Required for marked strings in Python source to be translated.
         # See http://docs.python.org/release/2.7/library/locale.html
         p = gettext.bindtextdomain(dom, path)
-        c = gettext.bind_textdomain_codeset(dom, codeset)
         logger.debug("Python bindtextdomain(%r, %r): %r", dom, path, p)
-        logger.debug(
-            "Python bind_textdomain_codeset(%r, %r): %r",
-            dom, codeset, c,
-        )
-    if bindtextdomain and bind_textdomain_codeset and textdomain:
+    if bindtextdomain and textdomain:
         if sys.platform == 'win32':
             d = textdomain(defaultdom.encode('utf-8'))
         else:

--- a/setup.py
+++ b/setup.py
@@ -679,7 +679,7 @@ class InstallScripts (install_scripts):
         self.announce("installing %s as %s" % (src, targ_basename), level=2)
         if self.dry_run:
             return []
-        with open(src, "rU") as in_fp:
+        with open(src, "r") as in_fp:
             with open(targ, "w") as out_fp:
                 line = in_fp.readline().rstrip()
                 if line.startswith("#!"):


### PR DESCRIPTION
- python 3 always open in universal mode, U is default mode in 3.0, and removed in 3.11
- mypaint doesn't use ld?n?gettext, so bind_textdomain_codeset isn't needed, that function is deprecated in 3.8 and is no-ops in 3.10 and removed in 3.11