### PR TITLE
Use standard cursor name

### DIFF
--- a/gui/brushmanip.py
+++ b/gui/brushmanip.py
@@ -201,7 +201,7 @@ class BrushResizeMode(gui.mode.OneshotDragMode):
 
     @property
     def active_cursor(self):
-        return Gdk.Cursor.new(Gdk.CursorType.BLANK_CURSOR)
+        return Gdk.Cursor.new_from_name(Gdk.Display.get_default(), "none")
 
     def enter(self, doc, **kwds):
         super(BrushResizeMode, self).enter(doc, **kwds)

--- a/gui/buttonmap.py
+++ b/gui/buttonmap.py
@@ -561,7 +561,7 @@ class ButtonMappingEditor (Gtk.EventBox):
         window = evbox.get_window()
         disp = window.get_display()
         try:  # Wayland themes are a bit incomplete
-            cursor = Gdk.Cursor.new_for_display(disp, Gdk.CursorType.CROSSHAIR)
+            cursor = Gdk.Cursor.new_from_name(disp, "crosshair")
             window.set_cursor(cursor)
         except Exception:
             logger.exception("Cursor setting failed")  # and otherwise ignore

--- a/gui/colors/adjbases.py
+++ b/gui/colors/adjbases.py
@@ -112,8 +112,8 @@ class ColorManager (GObject.GObject):
         self._palette = None  #: Current working palette
         self._adjusters = weakref.WeakSet()  #: The set of registered adjusters
         #: Cursor for pickers
-        # FIXME: Use Gdk.Cursor.new_for_display()
-        self._picker_cursor = Gdk.Cursor.new(Gdk.CursorType.CROSSHAIR)
+        self._picker_cursor = Gdk.Cursor.new_from_name(
+            Gdk.Display.get_default(), "crosshair")
         self._datapath = datapath  #: Base path for saving palettes and masks
         self._hue_distorts = None  #: Hue-remapping table for color wheels
         self._prefs = prefs  #: Shared preferences dictionary

--- a/gui/colors/hcywheel.py
+++ b/gui/colors/hcywheel.py
@@ -431,14 +431,13 @@ class HCYMaskEditorWheel (HCYHueChromaWheel):
     def _realize_cb(self, widget):
         display = self.get_window().get_display()
 
-        self.__add_cursor = Gdk.Cursor.new_for_display(
-            display, Gdk.CursorType.PLUS)
-        self.__move_cursor = Gdk.Cursor.new_for_display(
-            display, Gdk.CursorType.FLEUR)
-        self.__move_point_cursor = Gdk.Cursor.new_for_display(
-            display, Gdk.CursorType.CROSSHAIR)
-        self.__rotate_cursor = Gdk.Cursor.new_for_display(
-            display, Gdk.CursorType.EXCHANGE)
+        # non-standard cursor
+        self.__add_cursor = Gdk.Cursor.new_from_name(display, "plus")
+        self.__move_cursor = Gdk.Cursor.new_from_name(display, "move")
+        self.__move_point_cursor = Gdk.Cursor.new_from_name(
+            display, "crosshair")
+        # non-standard cursor
+        self.__rotate_cursor = Gdk.Cursor.new_from_name(display, "exchange")
 
     def __leave_cb(self, widget, event):
         # Reset the active objects when the pointer leaves.

--- a/gui/colors/hcywheel.py
+++ b/gui/colors/hcywheel.py
@@ -431,13 +431,20 @@ class HCYMaskEditorWheel (HCYHueChromaWheel):
     def _realize_cb(self, widget):
         display = self.get_window().get_display()
 
-        # non-standard cursor
-        self.__add_cursor = Gdk.Cursor.new_from_name(display, "plus")
+        try:
+            # non-standard cursor
+            self.__add_cursor = Gdk.Cursor.new_from_name(display, "plus")
+        except Exception:
+            self.__add_cursor = Gdk.Cursor.new_from_name(display, "default")
         self.__move_cursor = Gdk.Cursor.new_from_name(display, "move")
         self.__move_point_cursor = Gdk.Cursor.new_from_name(
             display, "crosshair")
-        # non-standard cursor
-        self.__rotate_cursor = Gdk.Cursor.new_from_name(display, "exchange")
+        try:
+            # non-standard cursor
+            self.__rotate_cursor = Gdk.Cursor.new_from_name(
+                display, "exchange")
+        except Exception:
+            self.__rotate_cursor = Gdk.Cursor.new_from_name(display, "grab")
 
     def __leave_cb(self, widget, event):
         # Reset the active objects when the pointer leaves.

--- a/gui/cursor.py
+++ b/gui/cursor.py
@@ -387,10 +387,12 @@ class CustomCursorMaker (object):
         # Find a small action icon for the overlay
         action = self.app.find_action(action_name)
         if action is None:
-            return Gdk.Cursor.new(Gdk.CursorType.ARROW)
+            return Gdk.Cursor.new_from_name(
+                Gdk.Display.get_default(), "default")
         icon_name = action.get_icon_name()
         if icon_name is None:
-            return Gdk.Cursor.new(Gdk.CursorType.ARROW)
+            return Gdk.Cursor.new_from_name(
+                Gdk.Display.get_default(), "default")
         return self.get_icon_cursor(icon_name, cursor_name)
 
     def get_icon_cursor(self, icon_name, cursor_name=Name.ARROW):

--- a/gui/freehand.py
+++ b/gui/freehand.py
@@ -256,8 +256,7 @@ class FreehandMode (gui.mode.BrushworkModeMixin,
 
         if self._cursor_hidden is None:
             window = tdw.get_window()
-            cursor = Gdk.Cursor.new_for_display(
-                window.get_display(), Gdk.CursorType.BLANK_CURSOR)
+            cursor = Gdk.Cursor.new_from_name(window.get_display(), "none")
             self._cursor_hidden = cursor
 
         tdw.set_override_cursor(self._cursor_hidden)

--- a/gui/historypopup.py
+++ b/gui/historypopup.py
@@ -99,8 +99,7 @@ class HistoryPopup (windowing.PopupWindow):
         self.show_all()
 
         window = self.get_window()
-        cursor = Gdk.Cursor.new_for_display(
-            window.get_display(), Gdk.CursorType.CROSSHAIR)
+        cursor = Gdk.Cursor.new_from_name(window.get_display(), "crosshair")
         window.set_cursor(cursor)
 
     def leave(self, reason):

--- a/gui/layermanip.py
+++ b/gui/layermanip.py
@@ -165,8 +165,7 @@ class LayerMoveMode (gui.mode.ScrollableModeMixin,
             tdw.set_sensitive(False)
 
             window = tdw.get_window()
-            cursor = Gdk.Cursor.new_for_display(
-                window.get_display(), Gdk.CursorType.WATCH)
+            cursor = Gdk.Cursor.new_from_name(window.get_display(), "wait")
             tdw.set_override_cursor(cursor)
 
             self.final_modifiers = self.current_modifiers()

--- a/gui/tileddrawwidget.py
+++ b/gui/tileddrawwidget.py
@@ -577,8 +577,7 @@ class DrawCursorMixin(object):
         elif not layer.get_paintable():
             # Cursor to represent that one cannot draw.
             # Often a red circle with a diagonal bar through it.
-            c = Gdk.Cursor.new_for_display(
-                window.get_display(), Gdk.CursorType.CIRCLE)
+            c = Gdk.Cursor.new_from_name(window.get_display(), "not-allowed")
         elif app is None:
             logger.error("update_cursor: no app")
             return

--- a/gui/widgets.py
+++ b/gui/widgets.py
@@ -170,7 +170,8 @@ def with_wait_cursor(func):
     """python decorator that adds a wait cursor around a function"""
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):
-        wait_cursor = Gdk.Cursor.new(Gdk.CursorType.WATCH)
+        wait_cursor = Gdk.Cursor.new_from_name(
+            Gdk.Display.get_default(), "wait")
         toplevels = Gtk.Window.list_toplevels()
         toplevels = [t for t in toplevels if t.get_window() is not None]
         for toplevel in toplevels:

--- a/gui/windowing.py
+++ b/gui/windowing.py
@@ -140,14 +140,14 @@ class ChooserPopup (Gtk.Window):
     EDGE_SIZE = 12
     EDGE_CURSORS = {
         None: None,
-        Gdk.WindowEdge.NORTH_EAST: Gdk.CursorType.TOP_RIGHT_CORNER,
-        Gdk.WindowEdge.NORTH_WEST: Gdk.CursorType.TOP_LEFT_CORNER,
-        Gdk.WindowEdge.SOUTH_EAST: Gdk.CursorType.BOTTOM_RIGHT_CORNER,
-        Gdk.WindowEdge.SOUTH_WEST: Gdk.CursorType.BOTTOM_LEFT_CORNER,
-        Gdk.WindowEdge.WEST: Gdk.CursorType.LEFT_SIDE,
-        Gdk.WindowEdge.EAST: Gdk.CursorType.RIGHT_SIDE,
-        Gdk.WindowEdge.SOUTH: Gdk.CursorType.BOTTOM_SIDE,
-        Gdk.WindowEdge.NORTH: Gdk.CursorType.TOP_SIDE,
+        Gdk.WindowEdge.NORTH_EAST: "ne-resize",
+        Gdk.WindowEdge.NORTH_WEST: "nw-resize",
+        Gdk.WindowEdge.SOUTH_EAST: "se-resize",
+        Gdk.WindowEdge.SOUTH_WEST: "sw-resize",
+        Gdk.WindowEdge.WEST: "w-resize",
+        Gdk.WindowEdge.EAST: "e-resize",
+        Gdk.WindowEdge.SOUTH: "s-resize",
+        Gdk.WindowEdge.NORTH: "n-resize",
     }
 
     ## Method defs
@@ -175,7 +175,8 @@ class ChooserPopup (Gtk.Window):
         self._prefs_size_key = "%s.window_size" % (config_name,)
         self._resize_info = None   # state during an edge resize
         self._outside_grab_active = False
-        self._outside_cursor = Gdk.Cursor(Gdk.CursorType.LEFT_PTR)
+        self._outside_cursor = Gdk.Cursor.new_from_name(
+            self.get_display(), "default")
         self._popup_info = None
 
         # Initial positioning
@@ -186,7 +187,7 @@ class ChooserPopup (Gtk.Window):
         self._edge_cursors = {}
         for edge, cursor in self.EDGE_CURSORS.items():
             if cursor is not None:
-                cursor = Gdk.Cursor(cursor)
+                cursor = Gdk.Cursor.new_from_name(self.get_display(), cursor)
             self._edge_cursors[edge] = cursor
 
         # Default size


### PR DESCRIPTION
Adwaita, the resident icon theme on GNOME removed the legacy X11 `circle` cursor: https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/commit/fb133a3989ee155c24201e30bab7dbc1c7c843fd

As a result, MyPaint would break when opening a file on GNOME systems.

Let’s use the equivalent `not-allowed` cursor from the XDG cursor-spec draft: https://www.freedesktop.org/wiki/Specifications/cursor-spec/

The circle cursor that was removed from Adwaita is in the fourth row, second column here: https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/blob/4d082e44e8361ca32360bb5b865be98a784ef4db/src/cursors/adwaita.svg
Here is the list of cursor constants supported by GDK 3 with images – it includes legacy X11 cursors: https://docs.gtk.org/gdk3/enum.CursorType.html
Here is the list of cursor names – only contains standard ones: https://docs.gtk.org/gdk3/ctor.Cursor.new_from_name.html

There was also simila  issue with the  `exchange` legacy X11 cursor when attempting to mask HCY wheel so Ifixed that as well.

And while at it, I switched to the preferred `Gdk.Cursor.new_from_name` API.

Fixes: https://github.com/mypaint/mypaint/issues/1209
