### PR TITLE
Fix exporting brushes with mtime 0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -81,7 +81,7 @@ installed before you can build it.
 - setuptools
 - pygobject
 - gtk3 (>= 3.12)
-- python (>= 2.7.4)
+- python (>= 3.8)
 - swig (>= 3)
 - numpy
 - librsvg2 (and its svg gdk-pixbuf loader)

--- a/gui/brushmanager.py
+++ b/gui/brushmanager.py
@@ -860,8 +860,12 @@ class BrushManager(object):
 
         """
         brushes = self.get_group_brushes(group)
-        order_conf = b"Group: %s\n" % utf8(group)
-        with zipfile.ZipFile(filename, mode="w") as zf:
+        order_conf = b'Group: %s\n' % utf8(group)
+        with zipfile.ZipFile(
+            filename,
+            mode='w',
+            strict_timestamps=False,
+        ) as zf:
             for brush in brushes:
                 prefix = brush._get_fileprefix()
                 zf.write(prefix + ".myb", brush.name + ".myb")


### PR DESCRIPTION
On NixOS, exporting a brush group by pressing “Export as Zipped Brushset” action in its properties fails with:

    ValueError: ZIP does not support timestamps before 1980

The `gui.brushmanager.BrushManager.export_group` doctest fails with the same error.

This is because Nix forces `mtime` of package files to 0 (1970-01-01) to ensure the build outputs are consistently reproducible.

Let’s disable strict timestamps to clamp the out-of-range timestamps to ZIP epoch. That argument was actually introduced in Python 3.8 because of reproducible builds: https://bugs.python.org/issue34097

This raises minimum version of Python to 3.8.
