### PR TITLE
Revert "Order imports with isort"

### DIFF
--- a/desktop/mypaint-ora-thumbnailer.py
+++ b/desktop/mypaint-ora-thumbnailer.py
@@ -29,6 +29,7 @@ import zipfile
 
 import gi
 
+
 gi.require_version("GdkPixbuf", "2.0")
 try:
     from lib.gibindings import GdkPixbuf

--- a/doc/spectral/rgb_to_spectral.py
+++ b/doc/spectral/rgb_to_spectral.py
@@ -9,19 +9,21 @@ Original file is located at
 
 # !pip install git+git://github.com/colour-science/colour
 
-
 import colour
 import numpy as np
+from scipy.optimize import minimize
+
+
 from colour.colorimetry import (
     STANDARD_OBSERVERS_CMFS,
     SpectralDistribution,
     SpectralShape,
     sd_ones,
-    sd_zeros,
     spectral_to_XYZ_integration,
+    sd_zeros,
 )
-from colour.utilities import from_range_100, to_domain_1
-from scipy.optimize import minimize
+from colour.utilities import to_domain_1, from_range_100
+
 
 # could use straight Meng but we can do Chromatic Adaptation via the illuminant_SPD instead
 # this is Meng modified to be more similar to Scott Allen Burns least log slope squared method

--- a/gui/accelmap.py
+++ b/gui/accelmap.py
@@ -14,10 +14,13 @@
 import logging
 import re
 
-import lib.xml
-from lib.gettext import C_
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import Pango
 from lib.gettext import gettext as _
-from lib.gibindings import Gdk, Gtk, Pango
+from lib.gettext import C_
+
+import lib.xml
 from lib.pycompat import unicode
 
 logger = logging.getLogger(__name__)

--- a/gui/application.py
+++ b/gui/application.py
@@ -28,68 +28,74 @@
 # guess GTK is caching something internally, like GLib's g_get_*_dir()
 # stuff, but wtf is libmypaint doing to break those?
 
-import json
-import logging
 import os
 import sys
-from collections import namedtuple
-from gettext import gettext as _
 from os.path import join
+from collections import namedtuple
+import logging
+import json
 
-import gui.autorecover
-import gui.compatibility as compat
-import gui.cursor
-import gui.device
-import gui.factoryaction  # registration only
-import gui.picker
-import gui.profiling
-import gui.userconfig
-import lib.cache
-import lib.config
-import lib.document
-import lib.fileutils
-import lib.glib
+from lib.gibindings import GObject
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GdkPixbuf
+from lib.gibindings import GLib
+from gettext import gettext as _
+
 import lib.observable
+import lib.cache
+import lib.document
 import lib.strokemap
-import lib.xml
-from lib import brush, brushsettings, helpers, mypaintlib, validation
-from lib.gibindings import Gdk, GdkPixbuf, GLib, GObject, Gtk
-from lib.pycompat import unicode
-
-from . import accelmap  # noqa: F401
-from . import colorpreview  # noqa: F401
-from . import colors  # noqa: F401
-from . import colortools  # noqa: F401
-from . import drawwindow  # noqa: F401
-from . import fill  # noqa: F401
-from . import framewindow  # noqa: F401
-from . import history  # noqa: F401
-from . import layerswindow  # noqa: F401
-from . import optionspanel  # noqa: F401
-from . import previewwindow  # noqa: F401
-from . import scratchwindow  # noqa: F401
-from . import toolbar  # noqa: F401
-from . import topbar  # noqa: F401
+from lib import brush
+from lib import helpers
+from lib import mypaintlib
+from lib import brushsettings
+from lib import validation
+import gui.compatibility as compat
+import gui.device
+from . import filehandling
+from . import keyboard
+from . import brushmanager
+from . import document
+from . import tileddrawwidget
 from . import workspace  # noqa: F401
-from . import (
-    backgroundwindow,
-    blendmodehandler,
-    brusheditor,
-    brushiconeditor,
-    brushmanager,
-    brushmodifier,
-    document,
-    filehandling,
-    inputtestwindow,
-    keyboard,
-    linemode,
-    preferenceswindow,
-    tileddrawwidget,
-)
+from . import topbar  # noqa: F401
+from . import drawwindow  # noqa: F401
+from . import backgroundwindow
+from . import preferenceswindow
+from . import brusheditor
+from . import layerswindow  # noqa: F401
+from . import previewwindow  # noqa: F401
+from . import optionspanel  # noqa: F401
+from . import framewindow  # noqa: F401
+from . import scratchwindow  # noqa: F401
+from . import inputtestwindow
+from . import brushiconeditor
+from . import history  # noqa: F401
+from . import colortools  # noqa: F401
+from . import brushmodifier
+from . import blendmodehandler
+from . import toolbar  # noqa: F401
+from . import linemode
+from . import colors  # noqa: F401
+from . import colorpreview  # noqa: F401
+from . import fill  # noqa: F401
+from . import accelmap  # noqa: F401
 from .brushcolor import BrushColorManager
-from .buttonmap import ButtonMapping
 from .overlays import LastPaintPosOverlay  # noqa: F401
 from .overlays import ScaleOverlay  # noqa: F401
+from .buttonmap import ButtonMapping
+import lib.config
+import lib.glib
+import gui.cursor
+import lib.fileutils
+import gui.picker
+import gui.userconfig
+import gui.factoryaction  # registration only
+import gui.autorecover
+import lib.xml
+import gui.profiling
+from lib.pycompat import unicode
 
 logger = logging.getLogger(__name__)
 

--- a/gui/autorecover.py
+++ b/gui/autorecover.py
@@ -9,16 +9,17 @@
 
 """Autorecovery UI"""
 
-import logging
-import os.path
-import shutil
 import weakref
+import os.path
 from gettext import gettext as _
+import shutil
+import logging
+
+from lib.gibindings import Gtk
 
 import lib.document
-import lib.errors
 import lib.helpers
-from lib.gibindings import Gtk
+import lib.errors
 from lib.pycompat import unicode
 
 logger = logging.getLogger(__name__)

--- a/gui/backgroundwindow.py
+++ b/gui/backgroundwindow.py
@@ -11,17 +11,21 @@
 
 ## Imports
 
-import logging
 import os
 import sys
+import logging
+
 from gettext import gettext as _
+from lib.gibindings import Gtk
+from lib.gibindings import GdkPixbuf
 
+from . import pixbuflist
+from . import windowing
+from lib import tiledsurface
+from lib import helpers
 import lib.pixbuf
-from lib import helpers, tiledsurface
-from lib.gibindings import GdkPixbuf, Gtk
-from lib.pycompat import unicode, xrange
-
-from . import pixbuflist, windowing
+from lib.pycompat import unicode
+from lib.pycompat import xrange
 
 logger = logging.getLogger(__name__)
 

--- a/gui/brushcolor.py
+++ b/gui/brushcolor.py
@@ -9,9 +9,8 @@
 
 """Brush color changer."""
 
-import lib.color
-
 from . import colors
+import lib.color
 
 
 class BrushColorManager(colors.ColorManager):

--- a/gui/brusheditor.py
+++ b/gui/brusheditor.py
@@ -13,24 +13,28 @@
 
 # Imports:
 
-import logging
 import os
+import logging
 
-import lib.brush
-from lib import brushsettings
+from lib.gibindings import Gtk
+from lib.gibindings import Pango
+from lib.gibindings import GLib
+from lib.gibindings import GdkPixbuf
+
 from lib.gettext import C_
-from lib.gibindings import GdkPixbuf, GLib, Gtk, Pango
+from lib import brushsettings
 from lib.pycompat import iteritems, itervalues
 
-from . import brushmanager
-from . import curve as notuseddirectly  # noqa - needed for interactive testing
+import lib.brush
 from . import dialogs
+from . import brushmanager
 from .builderhacks import add_objects_from_template_string
+from .windowing import SubWindow
+from . import curve as notuseddirectly  # noqa - needed for interactive testing
 
 # The widget class needs to be in scope before it is
 # instantiated via the loading of the glade file.
 from .sliderwidget import InputSlider  # noqa
-from .windowing import SubWindow
 
 logger = logging.getLogger(__name__)
 

--- a/gui/brushiconeditor.py
+++ b/gui/brushiconeditor.py
@@ -11,13 +11,17 @@
 import logging
 from gettext import gettext as _
 
+from lib.gibindings import Gtk
+from lib.gibindings import GLib
+
+from . import tileddrawwidget
+from . import windowing
 import lib.document
 from gui.document import CanvasController
-from lib.gibindings import GLib, Gtk
-from lib.observable import event
-
-from . import brushmanager, drawutils, tileddrawwidget, windowing
 from .freehand import FreehandMode
+from . import brushmanager
+from lib.observable import event
+from . import drawutils
 
 logger = logging.getLogger(__name__)
 

--- a/gui/brushmanager.py
+++ b/gui/brushmanager.py
@@ -12,28 +12,33 @@
 
 ## Imports
 
-import contextlib
-import logging
-import os
-import shutil
-import uuid
-import zipfile
 from itertools import chain
+import os
+import zipfile
 from os.path import basename
 from warnings import warn
+import logging
+import shutil
+import uuid
+import contextlib
 
+from lib.gettext import gettext as _
+from lib.gettext import C_
+from lib.helpers import utf8
+
+from lib.gibindings import Gtk
+from lib.gibindings import GdkPixbuf
+
+from . import dialogs
+from lib.brush import BrushInfo
+from lib.observable import event
+import lib.pixbuf
+from . import drawutils
 import gui.mode
 import lib.config
-import lib.pixbuf
-from lib.brush import BrushInfo
-from lib.gettext import C_
-from lib.gettext import gettext as _
-from lib.gibindings import GdkPixbuf, Gtk
-from lib.helpers import utf8
-from lib.observable import event
-from lib.pycompat import PY3, unicode, xrange
-
-from . import dialogs, drawutils
+from lib.pycompat import unicode
+from lib.pycompat import xrange
+from lib.pycompat import PY3
 
 if PY3:
     import urllib.parse
@@ -263,8 +268,8 @@ class BrushManager(object):
         any zipfile.Zipfile()s you open, even for read.
 
         """
-        from shutil import rmtree
         from tempfile import mkdtemp
+        from shutil import rmtree
 
         dist_brushes = lib.config.mypaint_brushdir
         tmp_user_brushes = mkdtemp(suffix="_brushes")

--- a/gui/brushmanip.py
+++ b/gui/brushmanip.py
@@ -11,11 +11,12 @@
 
 from math import ceil, hypot, log, pi
 
-import gui.mode
 import gui.overlays
+import gui.mode
+
 from lib.brush import brush_visual_radius
-from lib.gettext import C_
 from lib.gibindings import Gdk
+from lib.gettext import C_
 
 
 class BrushSizeOverlay(gui.overlays.Overlay):

--- a/gui/brushmodifier.py
+++ b/gui/brushmodifier.py
@@ -7,9 +7,9 @@
 # (at your option) any later version.
 
 from gettext import gettext as _
+from lib.helpers import rgb_to_hsv, hsv_to_rgb
 
 import gui.blendmodehandler
-from lib.helpers import hsv_to_rgb, rgb_to_hsv
 
 
 class BrushModifier(object):

--- a/gui/brushselectionwindow.py
+++ b/gui/brushselectionwindow.py
@@ -19,11 +19,18 @@ They are responsible for ordering, loading and saving brush lists.
 
 import logging
 
-from lib.gettext import C_, ngettext
-from lib.gibindings import GdkPixbuf, GLib, Gtk
+from lib.gibindings import Gtk
+from lib.gibindings import GdkPixbuf
+from lib.gibindings import GLib
 
-from . import brushmanager, dialogs, pixbuflist, widgets
+from lib.gettext import C_
+from lib.gettext import ngettext
+
+from . import pixbuflist
+from . import dialogs
+from . import brushmanager
 from .toolstack import SizedVBoxToolWidget
+from . import widgets
 
 logger = logging.getLogger(__name__)
 

--- a/gui/builderhacks.py
+++ b/gui/builderhacks.py
@@ -10,10 +10,11 @@
 
 """Hacks for loading stuff from GtkBuilder files."""
 
-import lib.xml
-
 ## Imports
 from lib.gibindings import Gtk
+
+import lib.xml
+
 
 ## Public functions
 

--- a/gui/buttonmap.py
+++ b/gui/buttonmap.py
@@ -8,14 +8,17 @@
 
 """Button press mapping."""
 
-import logging
 from gettext import gettext as _
+import logging
+
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GObject
+from lib.gibindings import Pango
 
 import lib.xml
-from lib.gibindings import Gdk, GObject, Gtk, Pango
-from lib.pycompat import unicode
-
 from . import widgets
+from lib.pycompat import unicode
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +108,7 @@ def get_handler_object(app, action_name):
     value None).
 
     """
-    from gui.mode import InteractionMode, ModeRegistry
+    from gui.mode import ModeRegistry, InteractionMode
 
     mode_class = ModeRegistry.get_mode_class(action_name)
     if mode_class is not None:

--- a/gui/colorpicker.py
+++ b/gui/colorpicker.py
@@ -12,10 +12,12 @@
 from gettext import gettext as _
 
 import gui.mode
+from .overlays import Overlay
+from .overlays import rounded_box
 from lib.color import HCYColor, HSVColor
+
 from lib.gibindings import GLib
 
-from .overlays import Overlay, rounded_box
 
 ## Color picking mode, with a preview rectangle overlay
 

--- a/gui/colors/__init__.py
+++ b/gui/colors/__init__.py
@@ -9,7 +9,9 @@
 
 """Color manipulation submodule."""
 
-from .adjbases import ColorAdjuster, ColorManager, PreviousCurrentColorAdjuster
+from .adjbases import ColorManager
+from .adjbases import ColorAdjuster
+from .adjbases import PreviousCurrentColorAdjuster
 from .hsvsquare import HSVSquare
 
 __all__ = [

--- a/gui/colors/adjbases.py
+++ b/gui/colors/adjbases.py
@@ -10,27 +10,32 @@
 """Manager+adjuster bases for tweaking a single color via many widgets.
 """
 
-import logging
 import math
-import os
-import weakref
-from copy import copy, deepcopy
-from gettext import gettext as _
+from copy import deepcopy, copy
 from warnings import warn
+import weakref
+import os
+import logging
+from gettext import gettext as _
 
+from lib.gibindings import GObject
+from lib.gibindings import Gdk
+from lib.gibindings import Gtk
+from lib.gibindings import GdkPixbuf
 import cairo
 
+from .util import clamp
+from .util import add_distance_fade_stops
+from .util import draw_marker_circle
+from lib.color import RGBColor, HCYColor
+from .bases import CachedBgDrawingArea
+from .bases import IconRenderable
+from . import uimisc
+from lib.palette import Palette
+from lib.observable import event
 import gui.dialogs
 import gui.uicolor
-from lib.color import HCYColor, RGBColor
-from lib.gibindings import Gdk, GdkPixbuf, GObject, Gtk
-from lib.observable import event
-from lib.palette import Palette
 from lib.pycompat import xrange
-
-from . import uimisc
-from .bases import CachedBgDrawingArea, IconRenderable
-from .util import add_distance_fade_stops, clamp, draw_marker_circle
 
 logger = logging.getLogger(__name__)
 

--- a/gui/colors/bases.py
+++ b/gui/colors/bases.py
@@ -11,9 +11,9 @@
 
 import logging
 
+from lib.gibindings import Gtk
 import cairo
 
-from lib.gibindings import Gtk
 
 logger = logging.getLogger(__name__)
 

--- a/gui/colors/changers.py
+++ b/gui/colors/changers.py
@@ -9,14 +9,17 @@
 
 """The old popup color changers wrapped as new-style Adjusters"""
 
-import gui.colors
-import gui.colors.adjbases
-import lib.color
-from lib import mypaintlib
 
 ## Imports
-from lib.gibindings import Gdk, GdkPixbuf
+from lib.gibindings import GdkPixbuf
+from lib.gibindings import Gdk
+
+import lib.color
+import gui.colors
+import gui.colors.adjbases
+from lib import mypaintlib
 from lib.helpers import gdkpixbuf2numpy
+
 
 ## Class definitions
 
@@ -123,10 +126,9 @@ class Rings(_CColorChanger):
 
 
 if __name__ == "__main__":
+    from lib.gibindings import Gtk
     import os
     import sys
-
-    from lib.gibindings import Gtk
 
     mgr = gui.colors.ColorManager(prefs={}, datapath=".")
     widget_classes = [CrossedBowl, Wash, Rings]

--- a/gui/colors/hcywheel.py
+++ b/gui/colors/hcywheel.py
@@ -12,30 +12,33 @@
 """
 
 import math
-import os.path
-import re
 from copy import deepcopy
+import re
+import os.path
 
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
 import cairo
 
+from .adjbases import ColorManager
+from .adjbases import ColorAdjuster
+from .adjbases import HueSaturationWheelMixin
+from .adjbases import HueSaturationWheelAdjuster
+from .sliders import HCYLumaSlider
+from .combined import CombinedAdjusterPage
+from lib.color import RGBColor
+from lib.color import HCYColor
+from lib.color import HSVColor
 import gui.uicolor
-import lib.alg as geom
-from lib.color import HCYColor, HSVColor, RGBColor
-from lib.gettext import C_
-from lib.gibindings import Gdk, Gtk
+from .util import clamp
 from lib.palette import Palette
+import lib.alg as geom
+from .paletteview import palette_load_via_dialog
+from .paletteview import palette_save_via_dialog
+from lib.gettext import C_
+
 from lib.pycompat import xrange
 
-from .adjbases import (
-    ColorAdjuster,
-    ColorManager,
-    HueSaturationWheelAdjuster,
-    HueSaturationWheelMixin,
-)
-from .combined import CombinedAdjusterPage
-from .paletteview import palette_load_via_dialog, palette_save_via_dialog
-from .sliders import HCYLumaSlider
-from .util import clamp
 
 PREFS_MASK_KEY = "colors.hcywheel.mask.gamuts"
 PREFS_ACTIVE_KEY = "colors.hcywheel.mask.active"

--- a/gui/colors/hsvcube.py
+++ b/gui/colors/hsvcube.py
@@ -14,24 +14,22 @@
 from gettext import gettext as _
 
 import cairo
-
-from lib.color import HSVColor, RGBColor
 from lib.gibindings import Gtk
-from lib.pycompat import xrange
 
-from .adjbases import (
-    ColorAdjuster,
-    ColorAdjusterWidget,
-    IconRenderableColorAdjusterWidget,
-    SliderColorAdjuster,
-)
+from .util import clamp
+from .util import draw_marker_circle
+from lib.color import HSVColor
+from lib.color import RGBColor
+from .adjbases import ColorAdjusterWidget
+from .adjbases import ColorAdjuster
+from .adjbases import SliderColorAdjuster
+from .adjbases import IconRenderableColorAdjusterWidget
 from .combined import CombinedAdjusterPage
-from .uimisc import (
-    PRIMARY_ADJUSTERS_MIN_HEIGHT,
-    PRIMARY_ADJUSTERS_MIN_WIDTH,
-    borderless_button,
-)
-from .util import clamp, draw_marker_circle
+from .uimisc import borderless_button
+from .uimisc import PRIMARY_ADJUSTERS_MIN_WIDTH
+from .uimisc import PRIMARY_ADJUSTERS_MIN_HEIGHT
+
+from lib.pycompat import xrange
 
 
 class HSVCubePage(CombinedAdjusterPage):
@@ -252,7 +250,6 @@ class HSVCubeSlice(IconRenderableColorAdjusterWidget):
 if __name__ == "__main__":
     import os
     import sys
-
     from adjbases import ColorManager
 
     mgr = ColorManager(prefs={}, datapath=".")

--- a/gui/colors/hsvsquare.py
+++ b/gui/colors/hsvsquare.py
@@ -14,21 +14,20 @@
 import math
 from gettext import gettext as _
 
+from lib.gibindings import Gtk
 import cairo
 
-from lib.color import HSVColor, RGBColor
-from lib.gibindings import Gtk
-from lib.pycompat import xrange
-
-from .adjbases import (
-    ColorAdjuster,
-    ColorAdjusterWidget,
-    HueSaturationWheelAdjuster,
-    IconRenderableColorAdjusterWidget,
-)
+from .util import clamp
+from .util import draw_marker_circle
+from lib.color import RGBColor, HSVColor
 from .bases import IconRenderable
+from .adjbases import ColorAdjusterWidget
+from .adjbases import ColorAdjuster
+from .adjbases import IconRenderableColorAdjusterWidget
+from .adjbases import HueSaturationWheelAdjuster
 from .combined import CombinedAdjusterPage
-from .util import clamp, draw_marker_circle
+
+from lib.pycompat import xrange
 
 
 class HSVSquarePage(CombinedAdjusterPage, IconRenderable):
@@ -420,7 +419,6 @@ class _HSVSquareInnerSquare(IconRenderableColorAdjusterWidget):
 if __name__ == "__main__":
     import os
     import sys
-
     from adjbases import ColorManager
 
     mgr = ColorManager(prefs={}, datapath=".")

--- a/gui/colors/hsvwheel.py
+++ b/gui/colors/hsvwheel.py
@@ -12,13 +12,14 @@
 
 from gettext import gettext as _
 
-from lib.color import HSVColor
-from lib.gibindings import Gdk, Gtk
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
 
 from .adjbases import HueSaturationWheelAdjuster
-from .combined import CombinedAdjusterPage
 from .sliders import HSVValueSlider
+from lib.color import HSVColor
 from .util import clamp
+from .combined import CombinedAdjusterPage
 
 
 class HSVHueSaturationWheel(HueSaturationWheelAdjuster):
@@ -104,7 +105,6 @@ class HSVAdjusterPage(CombinedAdjusterPage):
 if __name__ == "__main__":
     import os
     import sys
-
     from adjbases import ColorManager
 
     mgr = ColorManager(prefs={}, datapath=".")

--- a/gui/colors/paletteview.py
+++ b/gui/colors/paletteview.py
@@ -15,31 +15,33 @@
 #   - sort palette by approx. hue+chroma binning, then luma variations
 
 
-import logging
-
 ## Imports
 import math
 import os
 import re
+import logging
 from io import open
 
+from lib.gibindings import Gdk
+from lib.gibindings import Gtk
+from lib.gibindings import GLib
 import cairo
-
-import gui.uicolor
-from lib.color import HCYColor, HSVColor, RGBColor
 from lib.gettext import C_
-from lib.gibindings import Gdk, GLib, Gtk
+
+from .util import clamp
 from lib.palette import Palette
+from lib.color import RGBColor
+from lib.color import HCYColor
+from lib.color import HSVColor
+import gui.uicolor
+from .adjbases import ColorAdjuster
+from .adjbases import ColorAdjusterWidget
+from .adjbases import ColorManager
+from .adjbases import DATAPATH_PALETTES_SUBDIR
+from .combined import CombinedAdjusterPage
+
 from lib.pycompat import unicode
 
-from .adjbases import (
-    DATAPATH_PALETTES_SUBDIR,
-    ColorAdjuster,
-    ColorAdjusterWidget,
-    ColorManager,
-)
-from .combined import CombinedAdjusterPage
-from .util import clamp
 
 logger = logging.getLogger(__name__)
 

--- a/gui/colors/sliders.py
+++ b/gui/colors/sliders.py
@@ -10,13 +10,16 @@
 """Component sliders for power users.
 """
 
-from lib.color import HCYColor, HSVColor, RGBColor
-from lib.gettext import C_
 from lib.gibindings import Gtk
 
-from .adjbases import ColorAdjuster, SliderColorAdjuster
+from lib.color import RGBColor
+from lib.color import HSVColor
+from lib.color import HCYColor
 from .bases import IconRenderable
+from .adjbases import ColorAdjuster
+from .adjbases import SliderColorAdjuster
 from .combined import CombinedAdjusterPage
+from lib.gettext import C_
 
 
 class ComponentSlidersAdjusterPage(CombinedAdjusterPage, IconRenderable):
@@ -305,7 +308,6 @@ class HCYLumaSlider(SliderColorAdjuster):
 if __name__ == "__main__":
     import os
     import sys
-
     from adjbases import ColorManager
 
     mgr = ColorManager(prefs={}, datapath=".")

--- a/gui/colors/uimisc.py
+++ b/gui/colors/uimisc.py
@@ -12,6 +12,7 @@
 
 from lib.gibindings import Gtk
 
+
 ## Layout constants ##
 
 # Most pages in the old combined adjuster widget were split into a primary area

--- a/gui/colortools.py
+++ b/gui/colortools.py
@@ -9,19 +9,21 @@
 
 """Dockable Workspace tools for color adjusters."""
 
-import gui.colors.changers
-from gui.colors import ColorAdjuster
-from gui.colors.hcywheel import HCYAdjusterPage
-from gui.colors.hsvcube import HSVCubePage
-from gui.colors.hsvsquare import HSVSquarePage
-from gui.colors.hsvwheel import HSVAdjusterPage
-from gui.colors.paletteview import PalettePage
-from gui.colors.sliders import ComponentSlidersAdjusterPage
-from lib.gettext import C_
 from lib.gibindings import Gtk
+
+from lib.gettext import C_
 
 from . import widgets
 from .toolstack import TOOL_WIDGET_MIN_WIDTH
+from gui.colors.hcywheel import HCYAdjusterPage
+from gui.colors.hsvwheel import HSVAdjusterPage
+from gui.colors.paletteview import PalettePage
+from gui.colors.hsvcube import HSVCubePage
+from gui.colors.hsvsquare import HSVSquarePage
+from gui.colors.sliders import ComponentSlidersAdjusterPage
+import gui.colors.changers
+from gui.colors import ColorAdjuster
+
 
 ## Adapter classes for old-style "Page" ColorAdjuster classes
 

--- a/gui/compatibility.py
+++ b/gui/compatibility.py
@@ -9,16 +9,19 @@
 
 from logging import getLogger
 
-import lib.eotf
-from lib.gettext import C_
 from lib.gibindings import Gtk
-from lib.layer.data import BackgroundLayer
-from lib.meta import MYPAINT_VERSION, PREREL, Compatibility
-from lib.modes import MODE_STRINGS, set_default_mode
-from lib.mypaintlib import CombineNormal, CombineSpectralWGM, combine_mode_get_info
 
 from . import compatconfig as config
+
 from .compatconfig import C1X, C2X, COMPAT_SETTINGS, DEFAULT_COMPAT
+
+import lib.eotf
+from lib.layer.data import BackgroundLayer
+from lib.meta import Compatibility, PREREL, MYPAINT_VERSION
+from lib.modes import MODE_STRINGS, set_default_mode
+from lib.mypaintlib import CombineNormal, CombineSpectralWGM
+from lib.mypaintlib import combine_mode_get_info
+from lib.gettext import C_
 
 logger = getLogger(__name__)
 

--- a/gui/cursor.py
+++ b/gui/cursor.py
@@ -7,14 +7,16 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import logging
-import math
-
 import cairo
+import math
+import logging
 
 import gui.drawutils
-from lib.gibindings import Gdk, GdkPixbuf, Gtk
 from lib.pycompat import xrange
+
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GdkPixbuf
 
 logger = logging.getLogger(__name__)
 

--- a/gui/curve.py
+++ b/gui/curve.py
@@ -11,7 +11,8 @@
 import logging
 from math import pi
 
-from lib.gibindings import Gdk, Gtk
+from lib.gibindings import Gtk, Gdk
+
 from lib.helpers import clamp
 
 logger = logging.getLogger(__name__)

--- a/gui/device.py
+++ b/gui/device.py
@@ -12,15 +12,18 @@
 
 ## Imports
 
-import collections
 import logging
+import collections
 import re
 
+from lib.gettext import C_
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import Pango
+
+from lib.observable import event
 import gui.application
 import gui.mode
-from lib.gettext import C_
-from lib.gibindings import Gdk, Gtk, Pango
-from lib.observable import event
 
 logger = logging.getLogger(__name__)
 

--- a/gui/dialogs.py
+++ b/gui/dialogs.py
@@ -10,15 +10,18 @@
 
 """Common dialog functions"""
 
-from fnmatch import fnmatch
-from gettext import gettext as _
-
-from lib.color import RGBColor
-
 ## Imports
-from lib.gibindings import Gdk, GdkPixbuf, Gtk
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GdkPixbuf
 
-from . import uicolor, widgets
+from gettext import gettext as _
+from fnmatch import fnmatch
+
+from . import widgets
+from lib.color import RGBColor
+from . import uicolor
+
 
 ## Module constants
 

--- a/gui/displayfilter.py
+++ b/gui/displayfilter.py
@@ -13,6 +13,7 @@
 ## Imports
 import numpy as np
 
+
 ## Constants
 
 # sRGB coefficients: the usual sRGB / Rec. 709 ones

--- a/gui/document.py
+++ b/gui/document.py
@@ -16,37 +16,39 @@ i.e. they convert user input into updates to the document model.
 
 ## Imports
 
-import logging
-import math
 import os
 import os.path
-import weakref
+import math
 from warnings import warn
+import weakref
+import logging
 
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
+
+import lib.document
+import lib.layer
+import lib.helpers
+from lib.helpers import clamp
+import lib.observable
+from . import stategroup
 import gui.application
-import gui.backgroundwindow
-import gui.buttonmap
+import gui.mode
 import gui.colorpicker  # purely for registration
-import gui.device
-import gui.externalapp
+import gui.symmetry  # registration only
 import gui.freehand
 import gui.inktool  # registration only
 import gui.layerprops
-import gui.mode
-import gui.symmetry  # registration only
+import gui.buttonmap
+import gui.externalapp
+import gui.device
+import gui.backgroundwindow
 import gui.tileddrawwidget
-import lib.document
-import lib.helpers
-import lib.layer
-import lib.observable
 from gui.widgets import with_wait_cursor
-from lib.gettext import C_
 from lib.gettext import gettext as _
-from lib.gibindings import Gdk, GLib, Gtk
-from lib.helpers import clamp
+from lib.gettext import C_
 from lib.modes import PASS_THROUGH_MODE
-
-from . import stategroup
 
 logger = logging.getLogger(__name__)
 

--- a/gui/drawutils.py
+++ b/gui/drawutils.py
@@ -17,17 +17,19 @@ See also: gui.style
 import logging
 import math
 
-import cairo
-import numpy
-
+from lib.brush import Brush, BrushInfo
+import lib.tiledsurface
+from lib.pixbufsurface import render_as_pixbuf
+from lib.helpers import clamp
 import gui.style
 import lib.color
-import lib.tiledsurface
-from lib.brush import Brush, BrushInfo
-from lib.gibindings import Gdk, GdkPixbuf, Gtk
-from lib.helpers import clamp
-from lib.pixbufsurface import render_as_pixbuf
 from lib.pycompat import xrange
+
+import numpy
+import cairo
+from lib.gibindings import GdkPixbuf
+from lib.gibindings import Gdk
+from lib.gibindings import Gtk
 
 logger = logging.getLogger(__name__)
 
@@ -563,7 +565,6 @@ def get_drop_shadow_offsets(line_width, z=2):
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     import sys
-
     import lib.pixbuf
 
     for myb_file in sys.argv[1:]:

--- a/gui/drawwindow.py
+++ b/gui/drawwindow.py
@@ -16,45 +16,45 @@ Painting is done in tileddrawwidget.py.
 
 ## Imports
 
-import logging
-import math
 import os
 import os.path
 import webbrowser
-import xml.etree.ElementTree as ET
 from warnings import warn
+import logging
+import math
+import xml.etree.ElementTree as ET
 
-import gui.brushmanip  # noqa: F401
-import gui.displayfilter
-import gui.footer
-import gui.layermanip  # noqa: F401 (registration of GObject classes)
-import gui.meta
-import gui.picker
-import gui.tileddrawwidget
-import gui.viewmanip  # noqa: F401 (registration of GObject classes)
-import lib.glib
-import lib.xml
-from lib.color import HSVColor
-from lib.gettext import C_
-from lib.gettext import gettext as _
-from lib.gibindings import Gdk, Gtk
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
 
-from . import brushselectionwindow  # noqa: F401 (registration)
+from . import compatibility
+from . import historypopup
+from . import stategroup
 from . import colorpicker  # noqa: F401 (registration of GObject classes)
-from . import layermodes  # noqa: F401 (registration of GObject classes)
 from . import windowing  # noqa: F401 (registration of GObject classes)
-from . import (
-    compatibility,
-    dialogs,
-    historypopup,
-    quickchoice,
-    stategroup,
-    toolbar,
-    uicolor,
-)
+from . import toolbar
+from . import dialogs
+from . import layermodes  # noqa: F401 (registration of GObject classes)
+from . import quickchoice
+import gui.viewmanip  # noqa: F401 (registration of GObject classes)
+import gui.layermanip  # noqa: F401 (registration of GObject classes)
+import gui.brushmanip  # noqa: F401
+from lib.color import HSVColor
+from . import uicolor
+import gui.picker
+import gui.footer
+from . import brushselectionwindow  # noqa: F401 (registration)
+from .overlays import LastPaintPosOverlay
+from .overlays import ScaleOverlay
 from .framewindow import FrameOverlay
-from .overlays import LastPaintPosOverlay, ScaleOverlay
 from .symmetry import SymmetryOverlay
+import gui.tileddrawwidget
+import gui.displayfilter
+import gui.meta
+import lib.xml
+import lib.glib
+from lib.gettext import gettext as _
+from lib.gettext import C_
 
 logger = logging.getLogger(__name__)
 

--- a/gui/externalapp.py
+++ b/gui/externalapp.py
@@ -12,18 +12,24 @@
 
 ## Imports
 
-import logging
-import os
-import os.path
-import subprocess
 import weakref
+import os.path
+import os
+import subprocess
 
 import gui.document  # noqa
-import lib.xml
-from lib.gettext import C_
+
 from lib.gettext import gettext as _
-from lib.gibindings import Gio, Gtk, Pango
+from lib.gettext import C_
 from lib.layer.core import LayerBase  # noqa
+
+from lib.gibindings import Gio
+from lib.gibindings import Pango
+from lib.gibindings import Gtk
+
+import lib.xml
+
+import logging
 
 logger = logging.getLogger(__name__)
 

--- a/gui/factoryaction.py
+++ b/gui/factoryaction.py
@@ -12,8 +12,8 @@
 from warnings import warn
 
 import gi
-
-from lib.gibindings import GObject, Gtk
+from lib.gibindings import Gtk
+from lib.gibindings import GObject
 
 
 class FactoryAction(Gtk.Action):

--- a/gui/filehandling.py
+++ b/gui/filehandling.py
@@ -13,25 +13,31 @@
 
 ## Imports
 
-import logging
 import os
 import re
-import sys
-import time
-from collections import OrderedDict
 from glob import glob
+import sys
+import logging
+from collections import OrderedDict
+import time
 
+from lib.gibindings import Gtk
+from lib.gibindings import Pango
+
+from lib import helpers
+from lib import fileutils
+from lib.errors import FileHandlingError
+from lib.errors import AllocationError
 import gui.compatibility as compat
-import lib.feedback
-import lib.glib
-import lib.xml
 from gui.widgets import with_wait_cursor
-from lib import fileutils, helpers, mypaintlib
-from lib.errors import AllocationError, FileHandlingError
-from lib.gettext import C_, ngettext
-from lib.gibindings import Gtk, Pango
+from lib import mypaintlib
+from lib.gettext import ngettext
+from lib.gettext import C_
+import lib.glib
 from lib.glib import filename_to_unicode
-from lib.pycompat import PY3, unicode
+import lib.xml
+import lib.feedback
+from lib.pycompat import unicode, PY3
 
 logger = logging.getLogger(__name__)
 

--- a/gui/fill.py
+++ b/gui/fill.py
@@ -11,24 +11,28 @@
 
 # Imports
 import weakref
+from lib.gibindings import Gtk
+from lib.gibindings import Pango
+from lib.gibindings import GLib
 from gettext import gettext as _
+from lib.gettext import C_
 
 import cairo
 
-import gui.cursor
-import gui.layers
 import gui.mode
+import gui.cursor
+from gui.blendmodehandler import BlendModes
+import gui.layers
 import gui.overlays
+from gui.sliderwidget import InputSlider
+
 import lib.eotf
 import lib.floodfill
 import lib.helpers
+import lib.mypaintlib
 import lib.layer
 import lib.modes
-import lib.mypaintlib
-from gui.blendmodehandler import BlendModes
-from gui.sliderwidget import InputSlider
-from lib.gettext import C_
-from lib.gibindings import GLib, Gtk, Pango
+
 
 # Class defs
 

--- a/gui/footer.py
+++ b/gui/footer.py
@@ -9,19 +9,21 @@
 """Footer widget behaviour."""
 
 
-import logging
-
 ## Imports
 import math
-from gettext import gettext as _
+import logging
 
 import cairo
 
+from lib.gibindings import Gdk
+from lib.gibindings import GdkPixbuf
+
 import gui.brushmanager
-import lib.xml
 from gui.quickchoice import BrushChooserPopup  # noqa
+
+import lib.xml
 from lib.gettext import C_
-from lib.gibindings import Gdk, GdkPixbuf
+from gettext import gettext as _
 
 logger = logging.getLogger(__name__)
 

--- a/gui/framewindow.py
+++ b/gui/framewindow.py
@@ -10,25 +10,26 @@
 
 ## Imports
 
-import functools
 import math
-from gettext import gettext as _
+import functools
 
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
+from gettext import gettext as _
 import cairo
 
-import gui.cursor
-import gui.mode
-import gui.style
-import lib.helpers
 from gui.tileddrawwidget import TiledDrawWidget  # noqa
-from lib.alg import LineType, intersection_of_vector_and_poly, pairwise
+import gui.mode
 from lib.color import RGBColor
-from lib.document import DEFAULT_RESOLUTION
-from lib.gibindings import Gdk, GLib, Gtk
-from lib.helpers import Rect
-
+from lib.alg import pairwise, intersection_of_vector_and_poly, LineType
 from . import uicolor
 from .overlays import Overlay
+import lib.helpers
+from lib.helpers import Rect
+from lib.document import DEFAULT_RESOLUTION
+import gui.cursor
+import gui.style
 
 
 class _EditZone:

--- a/gui/freehand.py
+++ b/gui/freehand.py
@@ -10,18 +10,20 @@
 
 ## Imports
 
-import logging
 import math
+import logging
 from collections import deque
 from gettext import gettext as _
 
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
 import numpy as np
 
-import gui.mode
 from gui.tileddrawwidget import TiledDrawWidget
-from lib.gibindings import Gdk, GLib, Gtk
-from lib.helpers import clamp
 
+from lib.helpers import clamp
+import gui.mode
 from .drawutils import spline_4p
 from .sliderwidget import InputSlider
 

--- a/gui/gtkexcepthook.py
+++ b/gui/gtkexcepthook.py
@@ -17,25 +17,28 @@
 # - fix lockup with dialog.run(), return to mainloop instead
 # see also http://faq.pygtk.org/index.py?req=show&file=faq20.010.htp
 # (The license is still whatever you want.)
+from lib.pycompat import PY3
+
 import inspect
 import linecache
 import pydoc
 import sys
-import textwrap
 import traceback
 from gettext import gettext as _
+import textwrap
+
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import Pango
 
 import lib.meta
-from lib.gibindings import Gdk, Gtk, Pango
-from lib.pycompat import PY3
 
 if PY3:
     from io import StringIO
     from urllib.parse import quote_plus
 else:
-    from urllib import quote_plus
-
     from cStringIO import StringIO
+    from urllib import quote_plus
 
 
 # Function that will be called when the user presses "Quit"
@@ -71,10 +74,9 @@ def lookup(name, frame, lcls):
 
 
 def analyse(exctyp, value, tb):
+    import tokenize
     import keyword
     import platform
-    import tokenize
-
     from gui import application
     from gui.meta import get_libs_version_string
 
@@ -326,8 +328,8 @@ exception_dialog_active = False
 
 
 if __name__ == "__main__":
-    import os
     import sys
+    import os
 
     def _test_button_clicked_cb(*a):
         class _TestException(Exception):

--- a/gui/history.py
+++ b/gui/history.py
@@ -12,12 +12,15 @@
 
 ## Imports
 
-from lib.color import RGBColor
-from lib.gibindings import GdkPixbuf, GLib, Gtk
-from lib.observable import event
+from lib.gibindings import Gtk
+from lib.gibindings import GLib
+from lib.gibindings import GdkPixbuf
 
-from . import widgets
+from lib.color import RGBColor
 from .colors import ColorAdjuster
+from lib.observable import event
+from . import widgets
+
 
 ## Module constants
 

--- a/gui/historypopup.py
+++ b/gui/historypopup.py
@@ -7,11 +7,12 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
 import cairo
 
-from lib.gibindings import Gdk, Gtk
-
 from . import windowing
+
 
 """Color history popup."""
 

--- a/gui/inktool.py
+++ b/gui/inktool.py
@@ -9,24 +9,26 @@
 
 ## Imports
 
-import collections
 import math
+import collections
 import weakref
-from gettext import gettext as _
 from logging import getLogger
 
+from gettext import gettext as _
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
 import numpy as np
 
-import gui.cursor
-import gui.drawutils
 import gui.mode
-import gui.mvp
 import gui.overlays
 import gui.style
+import gui.drawutils
 import lib.helpers
+import gui.cursor
 import lib.observable
-from lib.gibindings import Gdk, GLib
+import gui.mvp
 from lib.pycompat import xrange
+
 
 ## Module constants
 

--- a/gui/inputtestwindow.py
+++ b/gui/inputtestwindow.py
@@ -10,7 +10,10 @@
 import logging
 from gettext import gettext as _
 
-from lib.gibindings import Gdk, GLib, Gtk, Pango
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
+from lib.gibindings import Pango
 
 from . import windowing
 

--- a/gui/keyboard.py
+++ b/gui/keyboard.py
@@ -17,9 +17,11 @@ for consistent keyboard handling.
 
 import logging
 
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+
 import gui.document
 import gui.tileddrawwidget
-from lib.gibindings import Gdk, Gtk
 
 logger = logging.getLogger(__name__)
 

--- a/gui/layermanip.py
+++ b/gui/layermanip.py
@@ -11,10 +11,13 @@
 ## Imports
 from gettext import gettext as _
 
-import gui.cursor
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
+
 import gui.mode
 import lib.command
-from lib.gibindings import Gdk, GLib
+import gui.cursor
+
 
 ## Class defs
 

--- a/gui/layermodes.py
+++ b/gui/layermodes.py
@@ -12,7 +12,11 @@
 ## Imports
 
 from lib.gibindings import Gtk
-from lib.modes import MODE_STRINGS, STACK_MODES, STANDARD_MODES
+
+from lib.modes import STACK_MODES
+from lib.modes import STANDARD_MODES
+from lib.modes import MODE_STRINGS
+
 
 ## Class definitions
 

--- a/gui/layerprops.py
+++ b/gui/layerprops.py
@@ -15,13 +15,19 @@
 import logging
 from collections import namedtuple
 
-import cairo
-
-import gui.mvp
+from lib.modes import STACK_MODES
+from lib.modes import STANDARD_MODES
+from lib.modes import PASS_THROUGH_MODE
+from lib.modes import MODE_STRINGS
 import lib.xml
 from lib.gettext import C_
-from lib.gibindings import Gdk, GdkPixbuf, Gtk
-from lib.modes import MODE_STRINGS, PASS_THROUGH_MODE, STACK_MODES, STANDARD_MODES
+import gui.mvp
+
+import cairo
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GdkPixbuf
+
 
 # Module constants:
 

--- a/gui/layers.py
+++ b/gui/layers.py
@@ -11,20 +11,28 @@
 
 ## Imports
 
-import logging
-import sys
-
-import gui.drawutils
 import lib.layer
-from gui.layerprops import make_preview
-from lib import helpers
-from lib.document import Document
-from lib.gettext import C_
-from lib.gettext import gettext as _
-from lib.gibindings import Gdk, GdkPixbuf, GLib, GObject, Gtk, Pango
-from lib.observable import event
-from lib.pycompat import unicode
 from lib.xml import escape
+from lib.observable import event
+from lib import helpers
+
+from lib.document import Document
+from lib.gettext import gettext as _
+from lib.gettext import C_
+from gui.layerprops import make_preview
+import gui.drawutils
+from lib.pycompat import unicode
+
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GObject
+from lib.gibindings import GLib
+from lib.gibindings import Pango
+from lib.gibindings import GdkPixbuf
+
+import sys
+import logging
+
 
 ## Module vars
 
@@ -1127,7 +1135,7 @@ def new_blend_mode_combo(modes, mode_strings):
 
 def _test():
     """Test the custom model in an ad-hoc GUI window"""
-    from lib.layer import LayerStack, PaintingLayer
+    from lib.layer import PaintingLayer, LayerStack
 
     doc_model = Document()
     root = doc_model.layer_stack

--- a/gui/layerswindow.py
+++ b/gui/layerswindow.py
@@ -13,20 +13,25 @@
 
 ## Imports
 
-import os.path
 from gettext import gettext as _
+import os.path
 from logging import getLogger
 
-import gui.layervis
-import lib.layer
-import lib.modes
-import lib.xml
-from lib.gibindings import GObject, Gtk
-from lib.modes import MODE_STRINGS, PASS_THROUGH_MODE, STACK_MODES, STANDARD_MODES
+from lib.gibindings import Gtk
+from lib.gibindings import GObject
 
-from . import layers, widgets
-from .toolstack import SizedVBoxToolWidget
+import lib.layer
+import lib.xml
+from . import widgets
 from .widgets import inline_toolbar
+from .toolstack import SizedVBoxToolWidget
+from . import layers
+from lib.modes import STACK_MODES
+from lib.modes import STANDARD_MODES
+from lib.modes import MODE_STRINGS
+from lib.modes import PASS_THROUGH_MODE
+import lib.modes
+import gui.layervis
 
 logger = getLogger(__name__)
 

--- a/gui/layervis.py
+++ b/gui/layervis.py
@@ -11,15 +11,16 @@
 
 # Imports:
 
-import logging
-
-import gui.application
-import gui.dialogs
 import gui.mvp
+import logging
+import gui.dialogs
+import gui.application
 import lib.layervis
 from lib.gettext import C_
-from lib.gibindings import Gtk
 from lib.xml import escape
+
+from lib.gibindings import Gtk
+
 
 # Module vars:
 

--- a/gui/linemode.py
+++ b/gui/linemode.py
@@ -17,16 +17,19 @@
 
 ## Imports
 
-import logging
 import math
+import logging
 from gettext import gettext as _
 
-import gui.cursor
-import gui.mode
-from lib.gibindings import Gdk, GLib, Gtk
-from lib.pycompat import xrange
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
 
 from .curve import CurveWidget
+import gui.mode
+import gui.cursor
+from lib.pycompat import xrange
+
 
 logger = logging.getLogger(__name__)
 

--- a/gui/main.py
+++ b/gui/main.py
@@ -11,18 +11,19 @@
 
 ## Imports *nothing involving mypaintlib at this point*
 
-import logging
 import os
 import sys
+import logging
 import warnings
+
+from lib.gibindings import GdkPixbuf
 from optparse import OptionParser
 
-import gui.userconfig
 import lib.config
 import lib.glib
-from lib.gibindings import GdkPixbuf
 from lib.i18n import USER_LOCALE_PREF
 from lib.meta import MYPAINT_VERSION
+import gui.userconfig
 
 logger = logging.getLogger(__name__)
 

--- a/gui/meta.py
+++ b/gui/meta.py
@@ -15,18 +15,20 @@ See also `lib.meta`.
 
 """
 
+## Imports
+import sys
 import os
 import platform
 
-## Imports
-import sys
-
+from lib.gibindings import Gtk
+from lib.gibindings import GdkPixbuf
+from lib.gibindings import GLib
 import cairo
 
-import lib.meta
 from lib.gettext import C_
-from lib.gibindings import GdkPixbuf, GLib, Gtk
+import lib.meta
 from lib.xml import escape
+
 
 ## Program-related string constants
 

--- a/gui/mode.py
+++ b/gui/mode.py
@@ -14,15 +14,21 @@ import logging
 import math
 from gettext import gettext as _
 
-import gui.cursor
-import lib.command
 from gui.sliderwidget import InputSlider
+
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
+
+import lib.command
 from lib.brushsettings import settings_dict
 from lib.document import Document
-from lib.gibindings import Gdk, GLib, Gtk
 from lib.layer.data import SimplePaintingLayer
 from lib.observable import event
-from lib.pycompat import add_metaclass, unicode
+from lib.pycompat import add_metaclass
+from lib.pycompat import unicode
+
+import gui.cursor
 
 logger = logging.getLogger(__name__)
 

--- a/gui/mvp.py
+++ b/gui/mvp.py
@@ -11,13 +11,14 @@
 
 # Imports:
 
+import os
+import inspect
 import abc
 import functools
-import inspect
 import logging
-import os
 
 from lib.gibindings import Gtk
+
 
 logger = logging.getLogger(__name__)
 

--- a/gui/objfactory.py
+++ b/gui/objfactory.py
@@ -14,6 +14,7 @@ import logging
 from warnings import warn
 
 from lib.gibindings import GObject
+
 from lib.observable import event
 
 logger = logging.getLogger(__name__)

--- a/gui/optionspanel.py
+++ b/gui/optionspanel.py
@@ -12,11 +12,11 @@
 
 import logging
 
+from .toolstack import SizedVBoxToolWidget, TOOL_WIDGET_NATURAL_HEIGHT_SHORT
 import lib.xml
 from lib.gettext import C_
-from lib.gibindings import Gtk
 
-from .toolstack import TOOL_WIDGET_NATURAL_HEIGHT_SHORT, SizedVBoxToolWidget
+from lib.gibindings import Gtk
 
 logger = logging.getLogger(__name__)
 

--- a/gui/overlays.py
+++ b/gui/overlays.py
@@ -11,14 +11,17 @@
 
 ## Imports
 
-from gettext import gettext as _
 from math import pi
+from gettext import gettext as _
 
+from lib.gibindings import Pango
+from lib.gibindings import PangoCairo
+from lib.gibindings import GLib
 import cairo
 
-import gui.style
-from lib.gibindings import GLib, Pango, PangoCairo
 from lib.helpers import clamp
+import gui.style
+
 
 ## Base classes and utils
 

--- a/gui/picker.py
+++ b/gui/picker.py
@@ -15,16 +15,18 @@ with a rather wide scope.
 
 """
 
-import abc
-import logging
-
-import gui.cursor
-from gui.document import Document
-
 ## Imports
 from gui.tileddrawwidget import TiledDrawWidget
+from gui.document import Document
 from lib.gettext import C_
-from lib.gibindings import Gdk, GLib, Gtk
+import gui.cursor
+
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
+
+import abc
+import logging
 
 logger = logging.getLogger(__name__)
 

--- a/gui/pixbuflist.py
+++ b/gui/pixbuflist.py
@@ -7,15 +7,18 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import logging
 from math import ceil
+import logging
+
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GdkPixbuf
+from lib.gibindings import GLib
 
 from lib import helpers
-from lib.gibindings import Gdk, GdkPixbuf, GLib, Gtk
 from lib.observable import event
-from lib.pycompat import xrange
-
 from . import uicolor
+from lib.pycompat import xrange
 
 logger = logging.getLogger(__name__)
 

--- a/gui/preferenceswindow.py
+++ b/gui/preferenceswindow.py
@@ -10,17 +10,19 @@
 """Preferences dialog."""
 
 import os.path
-from gettext import gettext as _
 from logging import getLogger
+from gettext import gettext as _
 
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+
+from gui.compatibility import CompatibilityPreferences
 import lib.config
 import lib.localecodes
-from gui.compatibility import CompatibilityPreferences
-from lib.gettext import C_
-from lib.gibindings import Gdk, Gtk
 from lib.i18n import USER_LOCALE_PREF
-
+from lib.gettext import C_
 from . import windowing
+
 
 logger = getLogger(__name__)
 RESPONSE_REVERT = 1

--- a/gui/previewwindow.py
+++ b/gui/previewwindow.py
@@ -9,21 +9,25 @@
 
 ## Imports
 
-import bisect
 import math
+import bisect
+
 from gettext import gettext as _
 
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
 import cairo
 
+import gui.mode
+from . import overlays
+from . import tileddrawwidget
+from .toolstack import SizedVBoxToolWidget, TOOL_WIDGET_NATURAL_HEIGHT_SHORT
+import lib.alg as geom
 import gui.cursor
 import gui.drawutils
-import gui.mode
 import gui.style
-import lib.alg as geom
-from lib.gibindings import Gdk, GLib, Gtk
 
-from . import overlays, tileddrawwidget
-from .toolstack import TOOL_WIDGET_NATURAL_HEIGHT_SHORT, SizedVBoxToolWidget
 
 ## Module consts
 

--- a/gui/profiling.py
+++ b/gui/profiling.py
@@ -8,16 +8,19 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import logging
 import os
-import shutil
-import subprocess
 import sys
-import tempfile
 import time
+import tempfile
+import subprocess
+import shutil
+import logging
+
+from lib.gibindings import GLib
+from lib.gibindings import Gtk
 
 import lib.fileutils
-from lib.gibindings import GLib, Gtk
+
 
 logger = logging.getLogger(__name__)
 

--- a/gui/quickchoice.py
+++ b/gui/quickchoice.py
@@ -12,13 +12,18 @@
 
 import abc
 
-import gui.colortools
 from lib.gibindings import Gtk
+
+from .pixbuflist import PixbufList
+from . import brushmanager
+from . import brushselectionwindow
+from . import widgets
+from . import spinbox
+from . import windowing
 from lib.observable import event
+import gui.colortools
 from lib.pycompat import add_metaclass
 
-from . import brushmanager, brushselectionwindow, spinbox, widgets, windowing
-from .pixbuflist import PixbufList
 
 ## Module consts
 

--- a/gui/scratchwindow.py
+++ b/gui/scratchwindow.py
@@ -14,10 +14,10 @@
 import logging
 
 from lib.gettext import gettext as _
-from lib.gibindings import Gtk
-
-from .toolstack import TOOL_WIDGET_NATURAL_HEIGHT_SHORT, SizedVBoxToolWidget
+from .toolstack import SizedVBoxToolWidget, TOOL_WIDGET_NATURAL_HEIGHT_SHORT
 from .widgets import inline_toolbar
+
+from lib.gibindings import Gtk
 
 logger = logging.getLogger(__name__)
 

--- a/gui/sliderwidget.py
+++ b/gui/sliderwidget.py
@@ -10,9 +10,14 @@
 
 import weakref
 
-from lib.gibindings import Gdk, GObject, Gtk
-from lib.observable import event
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GObject
+
 from lib.pycompat import with_metaclass
+
+from lib.observable import event
+
 
 # Can't access the constant as a normal attribute - it starts with a digit.
 _DOUBLE_CLICK = getattr(Gdk.EventType, "2BUTTON_PRESS")

--- a/gui/stategroup.py
+++ b/gui/stategroup.py
@@ -9,7 +9,10 @@
 
 import logging
 
-from lib.gibindings import Gdk, GLib, Gtk
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
+
 
 logger = logging.getLogger(__name__)
 

--- a/gui/style.py
+++ b/gui/style.py
@@ -18,6 +18,7 @@ See also: gui.drawutils
 
 from lib.color import HCYColor, RGBColor
 
+
 ## Alpha checks (chequerboard pattern)
 
 ALPHA_CHECK_SIZE = 16

--- a/gui/symmetry.py
+++ b/gui/symmetry.py
@@ -9,33 +9,37 @@
 # (at your option) any later version.
 
 
-import math
-
 # Imports
 import cairo
+import math
 
+import gui.overlays
+import gui.mode
 import gui.cursor
 import gui.drawutils
-import gui.mode
-import gui.overlays
 import gui.style
-import gui.tileddrawwidget
 import gui.widgets
 import gui.windowing
+import gui.tileddrawwidget
+from gui.sliderwidget import InputSlider
+
 import lib.alg
 import lib.mypaintlib
 import lib.tiledsurface
-from gui.sliderwidget import InputSlider
-from lib.gettext import C_
-from lib.gibindings import Gdk, GLib, Gtk
-from lib.helpers import Rect
 from lib.mypaintlib import (
     SymmetryHorizontal,
+    SymmetryVertical,
+    SymmetryVertHorz,
     SymmetryRotational,
     SymmetrySnowflake,
-    SymmetryVertHorz,
-    SymmetryVertical,
 )
+from lib.helpers import Rect
+from lib.gettext import C_
+
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
+from lib.gibindings import Gtk
+
 
 # Module settings
 

--- a/gui/tileddrawwidget.py
+++ b/gui/tileddrawwidget.py
@@ -10,28 +10,29 @@
 
 ## Imports
 
+import random
+from math import floor, ceil, log, exp
+import math
+import weakref
 import contextlib
 import logging
-import math
-import random
-import weakref
-from math import ceil, exp, floor, log
 
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
 import cairo
 import numpy as np
 
-import gui.style
-import lib.alg
-import lib.color
-import lib.layer
-from lib import helpers, pixbufsurface, tiledsurface
-from lib.gibindings import Gdk, GLib, Gtk
+from lib import helpers, tiledsurface, pixbufsurface
 from lib.observable import event
-from lib.pycompat import xrange
-
+import lib.layer
 from . import cursor
 from .drawutils import render_checks
 from .windowing import clear_focus
+import gui.style
+import lib.color
+import lib.alg
+from lib.pycompat import xrange
 
 logger = logging.getLogger(__name__)
 

--- a/gui/tileddrawwidget.py
+++ b/gui/tileddrawwidget.py
@@ -11,7 +11,7 @@
 ## Imports
 
 import random
-from math import floor, ceil, log, exp
+from math import floor, ceil, log
 import math
 import weakref
 import contextlib

--- a/gui/toolbar.py
+++ b/gui/toolbar.py
@@ -18,6 +18,7 @@ from lib.gibindings import Gtk
 
 from . import widgets
 
+
 ## Module constants
 
 

--- a/gui/toolstack.py
+++ b/gui/toolstack.py
@@ -8,20 +8,25 @@
 
 """Toolstacks with panels that can be closed/detached/reordered"""
 
+from warnings import warn
 import logging
 import weakref
-from warnings import warn
 
-import lib.helpers
-import lib.xml
+from lib.gibindings import GObject
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
+
 from gui.windowing import set_initial_window_position
-from lib.gettext import C_
-from lib.gibindings import Gdk, GLib, GObject, Gtk
-from lib.pycompat import unicode, xrange
 
+import lib.xml
+import lib.helpers
 from . import objfactory
 from .widgets import borderless_button
 from .windowing import clear_focus
+from lib.gettext import C_
+from lib.pycompat import xrange
+from lib.pycompat import unicode
 
 logger = logging.getLogger(__name__)
 

--- a/gui/topbar.py
+++ b/gui/topbar.py
@@ -11,9 +11,11 @@
 ## Imports
 
 import logging
-from gettext import gettext as _
 
-from lib.gibindings import Gdk, GObject, Gtk
+from lib.gibindings import GObject
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from gettext import gettext as _
 
 logger = logging.getLogger(__name__)
 

--- a/gui/uicolor.py
+++ b/gui/uicolor.py
@@ -18,8 +18,9 @@ They can't be part of lib/ because of the GDK dependency.
 
 import struct
 
-from lib.color import RGBColor
 from lib.gibindings import Gdk
+
+from lib.color import RGBColor
 from lib.helpers import clamp
 
 

--- a/gui/userconfig.py
+++ b/gui/userconfig.py
@@ -8,15 +8,16 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import json
-import logging
 import os
 import sys
+import json
+import logging
+
+from lib.gibindings import GLib
 
 import lib.glib
-from gui.compatconfig import DEFAULT_CONFIG as COMPAT_CONFIG
 from lib.eotf import DEFAULT_EOTF
-from lib.gibindings import GLib
+from gui.compatconfig import DEFAULT_CONFIG as COMPAT_CONFIG
 
 logger = logging.getLogger(__name__)
 

--- a/gui/viewmanip.py
+++ b/gui/viewmanip.py
@@ -9,11 +9,13 @@
 """Modes for manipulating the view"""
 
 
-import math
-from gettext import gettext as _
-
 ## Imports
 import gui.mode
+
+import math
+
+from gettext import gettext as _
+
 
 ## Class defs
 

--- a/gui/widgets.py
+++ b/gui/widgets.py
@@ -10,7 +10,9 @@
 
 import functools
 
-from lib.gibindings import Gdk, Gtk
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+
 
 # Exact icon sizes
 

--- a/gui/windowing.py
+++ b/gui/windowing.py
@@ -13,8 +13,11 @@
 
 import logging
 
-from lib.gibindings import Gdk, GLib, Gtk
-from lib.helpers import Rect, clamp
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
+
+from lib.helpers import clamp, Rect
 from lib.pycompat import xrange
 
 logger = logging.getLogger(__name__)

--- a/gui/workspace.py
+++ b/gui/workspace.py
@@ -10,14 +10,17 @@
 
 ## Imports
 
-import logging
 from warnings import warn
+import logging
+
+from lib.gibindings import GObject
+from lib.gibindings import Gtk
+from lib.gibindings import Gdk
+from lib.gibindings import GLib
 
 from gui.toolstack import ToolStack, ToolStackWindow
 from gui.windowing import set_initial_window_position
-from lib.gibindings import Gdk, GLib, GObject, Gtk
 from lib.observable import event
-
 from . import objfactory
 
 logger = logging.getLogger(__name__)

--- a/lib/brush.py
+++ b/lib/brush.py
@@ -7,14 +7,17 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import copy
-import json
 import logging
+import copy
 import math
+import json
 
-from lib import brushsettings, helpers, mypaintlib
+from lib import mypaintlib
+from lib import helpers
+from lib import brushsettings
 from lib.eotf import eotf
-from lib.pycompat import PY3, unicode
+from lib.pycompat import unicode
+from lib.pycompat import PY3
 
 if PY3:
     from urllib.parse import unquote

--- a/lib/brushes_migrate_json.py
+++ b/lib/brushes_migrate_json.py
@@ -13,8 +13,8 @@ Usage: PYTHONPATH=. python -m lib/brushes_migrate_json [BRUSHDIR...]
 
 """
 
-import os
 import sys
+import os
 
 from lib import brush
 

--- a/lib/brushsettings.py
+++ b/lib/brushsettings.py
@@ -14,6 +14,7 @@
 
 import lib.mypaintlib as _mypaintlib
 
+
 # Public variables:
 
 #: List of info about all brush engine inputs known to libmypaint.

--- a/lib/color.py
+++ b/lib/color.py
@@ -21,11 +21,14 @@ with an adjuster does its type change to match the control's color space.
 
 ## Imports
 
-import colorsys
 import re
+import colorsys
 
 from lib.gibindings import GdkPixbuf
-from lib.pycompat import PY3, xrange
+
+from lib.pycompat import xrange
+from lib.pycompat import PY3
+
 
 ## Lightweight color objects
 

--- a/lib/command.py
+++ b/lib/command.py
@@ -10,20 +10,19 @@
 
 ## Imports
 
-import weakref
 from collections import deque
+from warnings import warn
 from copy import deepcopy
+import weakref
 from gettext import gettext as _
 from logging import getLogger
-from warnings import warn
 
 import lib.layer
 import lib.layer.data
-import lib.stroke
-from lib.observable import event
-from lib.pycompat import unicode
-
 from . import helpers
+from lib.observable import event
+import lib.stroke
+from lib.pycompat import unicode
 
 logger = getLogger(__name__)
 

--- a/lib/document.py
+++ b/lib/document.py
@@ -10,40 +10,44 @@
 
 ## Imports
 
-import json
-import logging
 import os
-import shutil
 import sys
+import zipfile
 import tempfile
 import time
-import xml.etree.ElementTree as ET
-import zipfile
-from collections import namedtuple
-from datetime import datetime
 from os.path import join
+import xml.etree.ElementTree as ET
 from warnings import warn
-
-import lib.brush as brush
-import lib.command as command
-import lib.feedback
-import lib.fileutils as fileutils
-import lib.glib
-import lib.helpers as helpers
-import lib.idletask
-import lib.layer as layer
-import lib.layervis
-import lib.meta
-import lib.pixbuf
-import lib.tiledsurface as tiledsurface
-import lib.xml
-from lib.cache import DEFAULT_CACHE_SIZE
-from lib.errors import AllocationError, FileHandlingError
+import shutil
+from datetime import datetime
+from collections import namedtuple
+import json
+import logging
 from lib.fileutils import safename
-from lib.gettext import C_
-from lib.gibindings import GLib, GObject
 from lib.naming import make_unique_name
-from lib.observable import ObservableDict, event
+
+from lib.gibindings import GObject
+from lib.gibindings import GLib
+
+import lib.meta
+import lib.helpers as helpers
+import lib.fileutils as fileutils
+import lib.tiledsurface as tiledsurface
+import lib.command as command
+import lib.layer as layer
+import lib.brush as brush
+from lib.observable import event
+from lib.observable import ObservableDict
+import lib.pixbuf
+from lib.cache import DEFAULT_CACHE_SIZE
+from lib.errors import FileHandlingError
+from lib.errors import AllocationError
+import lib.idletask
+from lib.gettext import C_
+import lib.xml
+import lib.glib
+import lib.feedback
+import lib.layervis
 from lib.pycompat import unicode
 
 logger = logging.getLogger(__name__)

--- a/lib/feedback.py
+++ b/lib/feedback.py
@@ -11,8 +11,9 @@
 
 # Imports:
 
-import lib.helpers
 from lib.observable import event
+import lib.helpers
+
 
 # Class defs:
 

--- a/lib/fileutils.py
+++ b/lib/fileutils.py
@@ -12,17 +12,19 @@
 
 ## Imports
 
-import functools
-import logging
 import os
 import os.path
-import shutil
 import sys
+import functools
+import logging
+import shutil
 import unicodedata
 
 import lib.helpers
-from lib.gibindings import Gio, GLib
 from lib.pycompat import unicode
+
+from lib.gibindings import GLib
+from lib.gibindings import Gio
 
 logger = logging.getLogger(__name__)
 

--- a/lib/fill_common.py
+++ b/lib/fill_common.py
@@ -8,10 +8,10 @@
 
 """Functions and constants common to fill and morphological operations"""
 
-import numpy
-
 import lib.helpers
 import lib.mypaintlib
+import numpy
+
 
 N = lib.mypaintlib.TILE_SIZE
 

--- a/lib/floodfill.py
+++ b/lib/floodfill.py
@@ -9,20 +9,22 @@
 """This module implements tile-based floodfill and related operations."""
 
 import logging
-import threading
 
 import numpy as np
+import threading
 
-import lib.fill_common as fc
+from lib.gibindings import GLib
+
 import lib.helpers
-import lib.modes
-import lib.morphology
 import lib.mypaintlib as myplib
 import lib.surface
 import lib.tiledsurface
-from lib.fill_common import _EMPTY_TILE, _FULL_TILE, _OPAQUE
 from lib.gettext import C_
-from lib.gibindings import GLib
+import lib.fill_common as fc
+from lib.fill_common import _OPAQUE, _FULL_TILE, _EMPTY_TILE
+import lib.modes
+import lib.morphology
+
 from lib.pycompat import iteritems
 
 logger = logging.getLogger(__name__)

--- a/lib/gettext.py
+++ b/lib/gettext.py
@@ -24,13 +24,12 @@ still uses a relative import, however.
 
 """
 
-import sys
 from warnings import warn
-
 from lib.gibindings import GLib
 
 # Set the default encoding like PyGTK
 from lib.pycompat import PY3
+import sys
 
 if not PY3:
     reload(sys)  # noqa: F821
@@ -42,6 +41,7 @@ if not PY3:
 
 from gettext import gettext  # noqa: F401 E402
 from gettext import ngettext  # noqa: F401 E402
+
 
 # Newer code should use C_() even for simple cases, and provide contexts
 # for translators.

--- a/lib/gettext_setup.py
+++ b/lib/gettext_setup.py
@@ -6,12 +6,12 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-# This imports the global gettext package, not lib/gettext
-import gettext
-import logging
 import os
 import sys
+import logging
 
+# This imports the global gettext package, not lib/gettext
+import gettext
 import lib.config as config
 
 logger = logging.getLogger(__file__)
@@ -39,7 +39,6 @@ def init_gettext(localepath):
     """
 
     import locale
-
     import lib.i18n
 
     # Required in Windows for the "Region and Language" settings

--- a/lib/glib.py
+++ b/lib/glib.py
@@ -22,8 +22,10 @@ unicode, and may not even be UTF-8). This module works around that.
 import logging
 import sys
 
+from lib.pycompat import PY3
+from lib.pycompat import unicode
+
 from lib.gibindings import GLib
-from lib.pycompat import PY3, unicode
 
 logger = logging.getLogger(__name__)
 

--- a/lib/helpers.py
+++ b/lib/helpers.py
@@ -7,23 +7,24 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import itertools
+from math import floor, isnan
+import os
+import hashlib
+import zipfile
 import colorsys
 import gc
-import hashlib
-import itertools
 import logging
-import os
 import sys
-import zipfile
-from math import floor, isnan
 
-import lib.glib
-import lib.pixbuf
-from lib.gettext import C_
 from lib.gibindings import GdkPixbuf
-from lib.pycompat import PY2, unicode
+from lib.gettext import C_
 
 from . import mypaintlib
+import lib.pixbuf
+import lib.glib
+from lib.pycompat import PY2
+from lib.pycompat import unicode
 
 logger = logging.getLogger(__name__)
 

--- a/lib/i18n.py
+++ b/lib/i18n.py
@@ -14,10 +14,10 @@ Stolen from QuodLibet (thanks, lazka!) <https://github.com/quodlibet
 
 """
 
-import locale
-import logging
 import os
 import sys
+import locale
+import logging
 
 logger = logging.getLogger(__name__)
 

--- a/lib/layer/__init__.py
+++ b/lib/layer/__init__.py
@@ -28,7 +28,7 @@ These can be listened to via the root layer stack.
 
 """
 
-from .core import *  # noqa: F401, F403
-from .data import *  # noqa: F401, F403
 from .group import *  # noqa: F401, F403
+from .data import *  # noqa: F401, F403
+from .core import *  # noqa: F401, F403
 from .tree import *  # noqa: F401, F403

--- a/lib/layer/core.py
+++ b/lib/layer/core.py
@@ -12,32 +12,29 @@
 
 ## Imports
 
-import abc
 import logging
 import os
-import weakref
 import xml.etree.ElementTree as ET
+import weakref
 from warnings import warn
+import abc
 
-import lib.fileutils
-import lib.helpers as helpers
-import lib.modes
-import lib.mypaintlib
-import lib.pixbuf
-import lib.strokemap
-import lib.tiledsurface
-import lib.xml
 from lib.gettext import C_
-from lib.modes import (
-    MODES_DECREASING_BACKDROP_ALPHA,
-    MODES_EFFECTIVE_AT_ZERO_ALPHA,
-    ORA_MODES_BY_OPNAME,
-    PASS_THROUGH_MODE,
-    STANDARD_MODES,
-)
-from lib.pycompat import unicode
-
+import lib.mypaintlib
+import lib.strokemap
+import lib.helpers as helpers
+import lib.fileutils
+import lib.pixbuf
+from lib.modes import PASS_THROUGH_MODE
+from lib.modes import STANDARD_MODES
+from lib.modes import ORA_MODES_BY_OPNAME
+from lib.modes import MODES_EFFECTIVE_AT_ZERO_ALPHA
+from lib.modes import MODES_DECREASING_BACKDROP_ALPHA
+import lib.modes
+import lib.xml
+import lib.tiledsurface
 from .rendering import Renderable
+from lib.pycompat import unicode
 
 logger = logging.getLogger(__name__)
 

--- a/lib/layer/data.py
+++ b/lib/layer/data.py
@@ -12,40 +12,41 @@
 """Data layer classes"""
 
 
-import contextlib
-import logging
-import os
-import shutil
-import struct
-import tempfile
-import time
-import uuid
-
 ## Imports
 import zlib
+import logging
+import os
+import time
+import tempfile
+import shutil
 from copy import deepcopy
 from random import randint
+import uuid
+import struct
+import contextlib
 
-import lib.autosave
-import lib.feedback
-import lib.fileutils
-import lib.helpers as helpers
-import lib.layer.error
-import lib.modes
-import lib.mypaintlib
-import lib.pixbuf
-import lib.strokemap
-import lib.tiledsurface as tiledsurface
-import lib.xml
 from lib.brush import BrushInfo
 from lib.gettext import C_
-from lib.pycompat import PY3, unicode
 from lib.tiledsurface import N
-
-from . import core, rendering
+import lib.tiledsurface as tiledsurface
+import lib.strokemap
+import lib.helpers as helpers
+import lib.fileutils
+import lib.pixbuf
+import lib.modes
+import lib.mypaintlib
+from . import core
+import lib.layer.error
+import lib.autosave
+import lib.xml
+import lib.feedback
+from . import rendering
+from lib.pycompat import PY3
+from lib.pycompat import unicode
 
 if PY3:
-    from io import BytesIO, StringIO
+    from io import StringIO
+    from io import BytesIO
 else:
     from cStringIO import StringIO
 

--- a/lib/layer/group.py
+++ b/lib/layer/group.py
@@ -15,21 +15,23 @@
 import logging
 from copy import copy
 
-import lib.autosave
-import lib.feedback
-import lib.fileutils
-import lib.helpers as helpers
-import lib.layer.core
-import lib.layer.error
+from lib.gettext import C_
 import lib.mypaintlib
 import lib.pixbufsurface
+import lib.helpers as helpers
+import lib.fileutils
+from lib.modes import STANDARD_MODES
+from lib.modes import STACK_MODES
+from lib.modes import PASS_THROUGH_MODE
+from . import core
+from . import data
+import lib.layer.error
 import lib.surface
-from lib.gettext import C_
-from lib.modes import PASS_THROUGH_MODE, STACK_MODES, STANDARD_MODES
-from lib.pycompat import unicode
-
-from . import core, data
+import lib.autosave
+import lib.feedback
+import lib.layer.core
 from .rendering import Opcode
+from lib.pycompat import unicode
 
 logger = logging.getLogger(__name__)
 

--- a/lib/layer/rendering.py
+++ b/lib/layer/rendering.py
@@ -17,6 +17,7 @@ and its "render_*()" methods.
 
 import abc
 
+
 # Public constants:
 
 

--- a/lib/layer/test.py
+++ b/lib/layer/test.py
@@ -15,8 +15,8 @@ def make_test_stack():
     :rtype: tuple
 
     """
-    import lib.layer.data
     import lib.layer.group
+    import lib.layer.data
     import lib.layer.tree
 
     root = lib.layer.tree.RootLayerStack(doc=None)

--- a/lib/layer/tree.py
+++ b/lib/layer/tree.py
@@ -13,31 +13,38 @@
 
 ## Imports
 
-import contextlib
-import logging
-import os.path
 import re
-from copy import copy, deepcopy
+import logging
+from copy import copy
+from copy import deepcopy
+import os.path
 from warnings import warn
+import contextlib
 
+from lib.gibindings import GdkPixbuf
+from lib.gibindings import GLib
 import numpy as np
 
-import lib.cache
-import lib.feedback
-import lib.helpers as helpers
-import lib.mypaintlib
-import lib.naming
-import lib.pixbuf
-import lib.tiledsurface as tiledsurface
 from lib.eotf import eotf
 from lib.gettext import C_
-from lib.gibindings import GdkPixbuf, GLib
-from lib.modes import MODES_DECREASING_BACKDROP_ALPHA, PASS_THROUGH_MODE
+import lib.mypaintlib
+import lib.tiledsurface as tiledsurface
+from lib.tiledsurface import TileAccessible
+from lib.tiledsurface import TileBlittable
+import lib.helpers as helpers
 from lib.observable import event
+import lib.pixbuf
+import lib.cache
+from lib.modes import PASS_THROUGH_MODE
+from lib.modes import MODES_DECREASING_BACKDROP_ALPHA
+from . import data
+from . import group
+from . import core
+from . import rendering
+import lib.feedback
+import lib.naming
 from lib.pycompat import xrange
-from lib.tiledsurface import TileAccessible, TileBlittable
 
-from . import core, data, group, rendering
 
 logger = logging.getLogger(__name__)
 

--- a/lib/layervis.py
+++ b/lib/layervis.py
@@ -26,11 +26,12 @@ the document changes accordingly. These transitions are undoable.
 
 import logging
 
-import lib.naming
-from lib.command import Command
 from lib.gettext import C_
+import lib.naming
 from lib.observable import event
+from lib.command import Command
 from lib.pycompat import unicode
+
 
 # Module vars:
 

--- a/lib/meta.py
+++ b/lib/meta.py
@@ -261,10 +261,10 @@ def _get_versions(gitprefix="gitexport"):
     to derive the additional information.
 
     """
-    import os
     import re
-    import subprocess
+    import os
     import sys
+    import subprocess
 
     # Establish some fallbacks for use when there's no .git present,
     # or no release_info.

--- a/lib/modes.py
+++ b/lib/modes.py
@@ -9,7 +9,6 @@
 """Layer mode constants"""
 
 from gettext import gettext as _
-
 import lib.mypaintlib
 
 #: Additional pass-through mode for layer groups (not saved, but reflected

--- a/lib/morphology.py
+++ b/lib/morphology.py
@@ -11,9 +11,10 @@ dilation, erosion and blur
 """
 import logging
 
-import lib.fill_common as fc
 import lib.mypaintlib as myplib
-from lib.fill_common import _EMPTY_TILE, _FULL_TILE
+
+import lib.fill_common as fc
+from lib.fill_common import _FULL_TILE, _EMPTY_TILE
 
 N = myplib.TILE_SIZE
 

--- a/lib/observable.py
+++ b/lib/observable.py
@@ -9,8 +9,8 @@
 
 """Observable method calls and C#-like syntactic sugar for events."""
 
-import logging
 import weakref
+import logging
 
 logger = logging.getLogger(__name__)
 

--- a/lib/palette.py
+++ b/lib/palette.py
@@ -14,16 +14,19 @@
 
 ## Imports
 
-import logging
 import re
 from copy import copy
-from io import open
+import logging
 
-from lib.color import UIColor  # noqa
-from lib.color import RGBColor, YCbCrColor
 from lib.helpers import clamp
 from lib.observable import event
-from lib.pycompat import PY3, unicode, xrange
+from lib.color import RGBColor
+from lib.color import YCbCrColor
+from lib.color import UIColor  # noqa
+from lib.pycompat import unicode
+from lib.pycompat import xrange
+from lib.pycompat import PY3
+from io import open
 
 logger = logging.getLogger(__name__)
 

--- a/lib/pixbuf.py
+++ b/lib/pixbuf.py
@@ -20,13 +20,14 @@ which are exposed on POSIX platforms.
 
 ## Imports
 
+from lib.gibindings import GdkPixbuf
+
+import lib.fileutils
+import lib.feedback
+
 import logging
 import os
 import zipfile  # noqa
-
-import lib.feedback
-import lib.fileutils
-from lib.gibindings import GdkPixbuf
 
 logger = logging.getLogger(__name__)
 

--- a/lib/pixbufsurface.py
+++ b/lib/pixbufsurface.py
@@ -13,17 +13,18 @@
 import contextlib
 from logging import getLogger
 
+from lib.gibindings import GdkPixbuf
+from lib.gibindings import Gdk
 import cairo
 
-import lib.feedback
-import lib.surface
+from . import mypaintlib
+from . import helpers
 from lib.eotf import eotf
+import lib.surface
+from lib.surface import TileAccessible, TileBlittable
 from lib.errors import AllocationError
 from lib.gettext import C_
-from lib.gibindings import Gdk, GdkPixbuf
-from lib.surface import TileAccessible, TileBlittable
-
-from . import helpers, mypaintlib
+import lib.feedback
 
 logger = getLogger(__name__)
 

--- a/lib/strokemap.py
+++ b/lib/strokemap.py
@@ -9,19 +9,19 @@
 
 ## Imports
 
-import math
 import struct
 import zlib
+import math
 from logging import getLogger
 from warnings import warn
 
 import numpy as np
 
+from . import mypaintlib
+from . import idletask
 import lib.tiledsurface as tiledsurface
-from lib.pycompat import PY3, iteritems
 from lib.surface import TileAccessible  # noqa
-
-from . import idletask, mypaintlib
+from lib.pycompat import PY3, iteritems
 
 logger = getLogger(__name__)
 TILE_SIZE = N = mypaintlib.TILE_SIZE

--- a/lib/surface.py
+++ b/lib/surface.py
@@ -11,18 +11,18 @@
 """Common interfaces & routines for surface and surface-like objects"""
 
 import abc
-import logging
 import os
+import logging
 
 import numpy as np
 
-import lib.feedback
+from . import mypaintlib
 import lib.helpers
 from lib.errors import FileHandlingError
 from lib.gettext import C_
+import lib.feedback
 from lib.pycompat import xrange
 
-from . import mypaintlib
 
 logger = logging.getLogger(__name__)
 

--- a/lib/tiledsurface.py
+++ b/lib/tiledsurface.py
@@ -11,26 +11,29 @@
 
 ## Imports
 
+import time
+import sys
+import os
 import contextlib
 import logging
-import os
-import sys
-import time
-from gettext import gettext as _
 
+from gettext import gettext as _
 import numpy as np
 
-import lib.feedback
-import lib.fileutils
-import lib.floodfill
-import lib.modes
-import lib.surface
+from . import mypaintlib
+from . import pixbufsurface
 from lib.eotf import eotf
-from lib.pycompat import PY3, itervalues, xrange
-from lib.surface import TileAccessible, TileBlittable, TileCompositable
-
-from . import mypaintlib, pixbufsurface
+import lib.surface
+from lib.surface import TileAccessible
+from lib.surface import TileBlittable
+from lib.surface import TileCompositable
 from .errors import FileHandlingError
+import lib.fileutils
+import lib.modes
+import lib.feedback
+import lib.floodfill
+from lib.pycompat import xrange
+from lib.pycompat import PY3, itervalues
 
 logger = logging.getLogger(__name__)
 

--- a/lib/xml.py
+++ b/lib/xml.py
@@ -12,9 +12,9 @@
 
 ## Imports
 
-import xml.etree.ElementTree as _ET
-
 from lib.pycompat import PY3
+
+import xml.etree.ElementTree as _ET
 
 ## Consts for XML dialects
 # Namespaces are registered by importing this module.

--- a/mypaint.py
+++ b/mypaint.py
@@ -20,12 +20,12 @@ It then passes control to gui.main.main() for command line launching.
 
 ## Imports (standard Python only at this point)
 
-import logging
+import sys
 import os
 import os.path
+from os.path import join, isdir, dirname, abspath
 import re
-import sys
-from os.path import abspath, dirname, isdir, join
+import logging
 
 logger = logging.getLogger("mypaint")
 if sys.version_info >= (3,):
@@ -103,7 +103,7 @@ def win32_unicode_argv():
     characters with '?'.
     """
     try:
-        from ctypes import POINTER, byref, c_int, cdll, windll
+        from ctypes import POINTER, byref, cdll, c_int, windll
         from ctypes.wintypes import LPCWSTR, LPWSTR
 
         get_cmd = cdll.kernel32.GetCommandLineW

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.isort]
-profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ verbosity=2
 
 [flake8]
 max-line-length = 120
-extend-select = B950,I001
+extend-select = B950
 ignore = E203,E266,E501,E701,W503,E251,E226,BLK100
 exclude =
     .git,

--- a/setup.py
+++ b/setup.py
@@ -2,28 +2,30 @@
 
 # Imports:
 
-import functools
+from contextlib import contextmanager
+import subprocess
 import glob
 import os
 import os.path
+from os.path import join, abspath, normpath
 import pprint
-import shutil
-import subprocess
 import sys
-import tempfile
 import textwrap
-from contextlib import contextmanager
+import tempfile
+import shutil
+import functools
+
+from setuptools import setup
+from setuptools import Extension
+from setuptools import Command
+from setuptools.command.build_ext import build_ext
+from setuptools.command.install import install
+from setuptools.command.install_scripts import install_scripts
 
 # setuptools must be imported first since they ensure
 # their distutils implementation will be used.
 from distutils.command.build import build
 from distutils.command.clean import clean
-from os.path import abspath, join, normpath
-
-from setuptools import Command, Extension, setup
-from setuptools.command.build_ext import build_ext
-from setuptools.command.install import install
-from setuptools.command.install_scripts import install_scripts
 
 # Constants
 

--- a/svg/symbolic-icons-extract.py
+++ b/svg/symbolic-icons-extract.py
@@ -11,12 +11,12 @@
 
 ## Imports
 import argparse
+from copy import deepcopy
 import gzip
 import logging
 import os
 import sys
 import xml.etree.ElementTree as ET
-from copy import deepcopy
 
 from scour.scour import start as scour_optimize
 

--- a/tests/compositeops.py
+++ b/tests/compositeops.py
@@ -2,17 +2,17 @@
 # Tests the layer compositing/blending code for correctness of its
 # advertized optimization flags.
 
-import unittest
 from random import random
+import unittest
 
 import numpy as np
 
+from . import paths
 from lib import mypaintlib
+from lib.tiledsurface import N
 from lib.modes import MODE_STRINGS
 from lib.pycompat import xrange
-from lib.tiledsurface import N
 
-from . import paths
 
 ALPHA_VALUES = (0.0, 0.5, 1.0)
 GREY_VALUES = (0.0, 0.25, 0.5, 0.75, 1.0)

--- a/tests/fill.py
+++ b/tests/fill.py
@@ -2,18 +2,21 @@
 
 # Imports:
 
-import contextlib
-import copy
+from time import time
 import os
 import sys
-import unittest
-from itertools import chain, product, repeat
 from os.path import join
-from time import time
-
-from lib import document, fill_common, floodfill, morphology, mypaintlib
+import unittest
+import contextlib
+import copy
+from itertools import repeat, chain, product
 
 from . import paths
+from lib import mypaintlib
+from lib import document
+from lib import floodfill
+from lib import fill_common
+from lib import morphology
 
 N = mypaintlib.TILE_SIZE
 

--- a/tests/localedata.py
+++ b/tests/localedata.py
@@ -1,6 +1,5 @@
 import unittest
 from glob import glob
-
 from lib import localecodes as lc
 
 

--- a/tests/mypaintlib.py
+++ b/tests/mypaintlib.py
@@ -2,20 +2,23 @@
 
 # Imports:
 
-import os
-import shutil
-import sys
-import tempfile
-import unittest
-from itertools import product
-from os.path import join
 from time import time
+from os.path import join
+from itertools import product
+import unittest
+import sys
+import os
+import tempfile
+import shutil
 
 import numpy as np
 
-from lib import brush, document, mypaintlib, tiledsurface
-
 from . import paths
+from lib import mypaintlib
+from lib import tiledsurface
+from lib import brush
+from lib import document
+
 
 N = mypaintlib.TILE_SIZE
 

--- a/tests/rendering.py
+++ b/tests/rendering.py
@@ -2,20 +2,19 @@
 
 # Imports:
 
-import math
+from os.path import join
 import sys
 import time
-import unittest
-from collections import namedtuple
-from os.path import join
-
+import math
 import cairo
-
-from lib import mypaintlib
-from lib.document import Document
-from lib.pycompat import PY3, xrange
+from collections import namedtuple
+import unittest
 
 from . import paths
+from lib import mypaintlib
+from lib.document import Document
+from lib.pycompat import xrange, PY3
+
 
 TEST_BIGIMAGE = "bigimage.ora"
 

--- a/tests/unported/guicontrol.py
+++ b/tests/unported/guicontrol.py
@@ -1,14 +1,16 @@
+import traceback
+import tempfile
 import os
 import sys
-import tempfile
-import traceback
+
+import numpy as np
 
 import gi
-import numpy as np
 
 try:
     gi.require_version("Gtk", "3.0")
-    from lib.gibindings import GObject, Gtk
+    from lib.gibindings import Gtk
+    from lib.gibindings import GObject
 except:
     raise
 

--- a/tests/unported/memory_leak.py
+++ b/tests/unported/memory_leak.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python
 
-import gc
-import os
-import sys
 from time import time
+import sys
+import os
+import gc
 
 import numpy as np
 
 os.chdir(os.path.dirname(__file__))
 sys.path.insert(0, "..")
 
+from lib import mypaintlib, tiledsurface, brush, document, command, helpers
 import guicontrol
-
-from lib import brush, command, document, helpers, mypaintlib, tiledsurface
 
 # loadtxt is known to leak memory, thus we run it only once
 # http://projects.scipy.org/numpy/ticket/1356

--- a/tests/unported/performance.py
+++ b/tests/unported/performance.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
-import cProfile
+import sys
 import os
 import subprocess
-import sys
-from time import sleep, time
+import cProfile
+from time import time, sleep
 import shutil
 
+import numpy as np
 
 import guicontrol
-import numpy as np
 
 start_measurement = -1
 stop_measurement = -2
@@ -207,7 +207,7 @@ def save_png_layer():
 
 @nogui_test
 def brushengine_paint_hires():
-    from lib import brush, tiledsurface
+    from lib import tiledsurface, brush
 
     s = tiledsurface.Surface()
     with open("brushes/v2/watercolor.myb") as fp:


### PR DESCRIPTION
This reverts commit 28a5e7681589a291002235142df6e4a0936767e8.
It broke 423950bec96d6057eac70442de577364d784a847, noqa-marked imports and the import ordering rules in `gui/application.py`.
Unfortunately, imports are just too full of side-effect to have them sorted automatically.

Also merge https://github.com/mypaint/mypaint/pull/1257 again so that the commits are preserved in history and we can actually revert them.
