### PR TITLE
sliderwidget.py: Use ParamSpec func over attr

### DIFF
--- a/gui/sliderwidget.py
+++ b/gui/sliderwidget.py
@@ -33,21 +33,21 @@ class ScaleDelegator(type(Gtk.Bin)):
 
     def __init__(cls, name, bases, dict):
         # Existing properties from shared ancestry
-        base = {p.name for p in Gtk.Bin.list_properties()}
+        base = {p.get_name() for p in Gtk.Bin.list_properties()}
         # Properties in GtkScale, but not GtkBin
-        to_add = [p for p in Gtk.Scale.list_properties() if p.name not in base]
+        to_add = [p for p in Gtk.Scale.list_properties() if p.get_name() not in base]
         for prop in to_add:
             val_type = prop.value_type
             setattr(
                 cls,
-                prop.name.replace("-", "_"),
+                prop.get_name().replace("-", "_"),
                 GObject.Property(
                     type=val_type.pytype if val_type.pytype else val_type,
-                    default=prop.default_value,
+                    default=prop.get_default_value(),
                 ),
             )
         # Store newly created property names to determine which to delegate
-        cls._scale_props = {p.name for p in to_add}
+        cls._scale_props = {p.get_name() for p in to_add}
         super(ScaleDelegator, cls).__init__(name, bases, dict)
 
 
@@ -85,7 +85,7 @@ class InputSlider(with_metaclass(ScaleDelegator, Gtk.Bin)):
 
     def _notify(self, _, prop):
         """Delegate property changes to the scale instance"""
-        name = prop.name
+        name = prop.get_name()
         if name in self._scale_props:
             self._scale.set_property(name, self.get_property(name))
 

--- a/lib/gibindings.py
+++ b/lib/gibindings.py
@@ -32,13 +32,6 @@ from gi.repository import GObject  # noqa
 from gi.repository import Pango  # noqa
 from gi.repository import PangoCairo  # noqa
 
-# This may look pointless, but is required to set up types
-# prior to their use, in dynamic property creation. See
-# gui/sliderwidget.py for an instance of this.
-for i in dir(Gdk):
-    getattr(Gdk, i)
-
-
 # The import of the actual Gtk bindings needs to be deferred until the locale
 # has been configured, in order for locale-specific layouts to be respected
 # (right-to-left layouts).


### PR DESCRIPTION
PyGObject doesn't cast the right type on ParamSpec instances whose attributes are referred to in a direct manner. Let's use ParamSpec methods instead.
https://lazka.github.io/pgi-docs/GObject-2.0/classes/ParamSpec.html

Also get rid of the hack that previously added GObject types (6a2f91a3)

@jtojnar ready for review