### PR TITLE
main.py: Remove SIGINT workaround

### DIFF
--- a/gui/main.py
+++ b/gui/main.py
@@ -225,11 +225,6 @@ def main(
             func = app.filehandler.confirm_destructive_action
             gtkexcepthook.quit_confirmation_func = func
 
-        # temporary workaround for gtk3 Ctrl-C bug:
-        # https://bugzilla.gnome.org/show_bug.cgi?id=622084
-        import signal
-
-        signal.signal(signal.SIGINT, signal.SIG_DFL)
         Gtk.main()
 
     if options.trace:


### PR DESCRIPTION
The bug is fixed now
https://bugzilla.gnome.org/show_bug.cgi?id=622084

Closes #1278