### PR TITLE
Replace tostring() with tobytes() in stroke.py

### DIFF
--- a/lib/stroke.py
+++ b/lib/stroke.py
@@ -41,7 +41,7 @@ class Stroke(object):
 
         states = brush.get_states_as_array()
         assert states.dtype == "float32"
-        self.brush_state = states.tostring()
+        self.brush_state = states.tobytes()
 
         self.brush = brush
         self.brush.new_stroke()  # resets the stroke_* members of the brush
@@ -82,7 +82,7 @@ class Stroke(object):
         # - for space: just gzip? use integer datatypes?
         # - for time: maybe already use array storage while recording?
         data = np.array(self.tmp_event_list, dtype="float64")
-        data = data.tostring()
+        data = data.tobytes()
         version = b"2"
         self.stroke_data = version + data
 


### PR DESCRIPTION
Because numpy removed the former function (in a minor release) with numpy/numpy#28254. The function was an alias, so there's no change in behavior, i.e. it always returned bytes.

See also 2a92b6baf452aba2cff3cc0a7782b301da3933d7, where the same function was already replaced in strokemap.py.