### PR TITLE
Remove hotfix from 5be6d448

### DIFF
--- a/gui/application.py
+++ b/gui/application.py
@@ -532,11 +532,6 @@ class Application(object):
         self.preferences.update(default_config.copy())
         user_config = gui.userconfig.get_json_config(self.user_confpath)
         self.preferences.update(user_config)
-        key = "input.button_mapping"
-        if "ColorPickerPopup" in self.preferences[key].values():
-            # old config file; users who never assigned any buttons would
-            # end up with Ctrl-Click color picker broken after upgrade
-            self.preferences[key] = default_config[key]
 
     def reset_compat_mode(self, update=True):
         """Reset compatibility mode to configured default"""


### PR DESCRIPTION
Commit https://github.com/mypaint/mypaint/commit/5be6d4489cb409e0f0d79a6073f525d0866ea41e fixes a config migration issue.

This fix was first released in version 1.2.0, which came out in 2015 (which is itself 2 years after the commit).

Should we remove it?