### PR TITLE
Fix AttributeError by replacing value_name with name

### DIFF
--- a/lib/glib.py
+++ b/lib/glib.py
@@ -190,7 +190,7 @@ def init_user_dir_caches():
         k = GLib.UserDirectory(i)
         logger.debug(
             "Init g_get_user_special_dir(%s): %r",
-            k.value_name,
+            k.name,    # FIXED!
             get_user_special_dir(k),
         )
 


### PR DESCRIPTION
This PR fixes AttributeError on Arch Linux by replacing deprecated 'value_name' with 'name'. Verified the fix works.