### PR TITLE
CI: Add librsvg2-common dependency for SVG thumbnails in tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ jobs:
                   libjson-c-dev \
                   liblcms2-dev \
                   libpng-dev \
+                  librsvg2-common \
                   python3-dev \
                   python-gi-dev \
                   python3-gi-cairo \


### PR DESCRIPTION
This adds a dependency for SVG pixbuf loader on Ubuntu GitHub Action runner so tests that load SVGs succeed.