### PR TITLE
Fix AttributeError on pygobject < 3.51.0

### DIFF
--- a/gui/device.py
+++ b/gui/device.py
@@ -266,6 +266,13 @@ class Monitor(object):
             return
         settings = self._device_settings.get(device)
         if not settings:
+
+            try:
+                source_kind = source.name
+            except AttributeError:
+                # Compatibility with PyGObject < 3.51
+                source_kind = source.value_name
+
             try:
                 vendor_id = device.get_vendor_id()
                 product_id = device.get_product_id()
@@ -276,7 +283,7 @@ class Monitor(object):
             logger.info(
                 "New device %r" " (%s, axes:%d, class=%s, vendor=%r, product=%r)",
                 device.get_name(),
-                source.name,
+                source_kind,
                 num_axes,
                 device.__class__.__name__,
                 vendor_id,
@@ -352,10 +359,16 @@ class Monitor(object):
         new_device.name = new_device.props.name
         new_device.source = new_device.props.input_source
 
+        try:
+            source_kind = new_device.source.name
+        except AttributeError:
+            # Compatibility with PyGObject < 3.51
+            source_kind = new_device.source.value_name
+
         logger.debug(
             "Device change: name=%r source=%s",
             new_device.name,
-            new_device.source.name,
+            source_kind,
         )
 
         # When editing brush settings, it is often more convenient to use the

--- a/gui/inputtestwindow.py
+++ b/gui/inputtestwindow.py
@@ -117,9 +117,14 @@ class InputTestWindow(windowing.SubWindow):
 
     def event2str(self, widget, event):
         t = str(getattr(event, "time", "-"))
+        try:
+            event_name = event.type.name
+        except AttributeError:
+            # Compatibility with PyGObject < 3.51
+            event_name = event.type.value_name
         msg = "% 6s % 15s" % (
             t[-6:],
-            event.type.name.replace("GDK_", ""),
+            event_name.replace("GDK_", ""),
         )
 
         if hasattr(event, "x") and hasattr(event, "y"):

--- a/lib/glib.py
+++ b/lib/glib.py
@@ -188,9 +188,16 @@ def init_user_dir_caches():
     # It doesn't matter if some of these are None
     for i in range(GLib.UserDirectory.N_DIRECTORIES):
         k = GLib.UserDirectory(i)
+
+        try:
+            dir_kind = k.name
+        except AttributeError:
+            # Compatibility with PyGObject < 3.51
+            dir_kind = k.value_name
+
         logger.debug(
             "Init g_get_user_special_dir(%s): %r",
-            k.name,
+            dir_kind,
             get_user_special_dir(k),
         )
 


### PR DESCRIPTION
This extracts changes from c6cbb04c0842d92d8ed97d5d8e00ddfb6e2d9068 into a helper function that supports both versions and wraps changes from 7e4ec24506aa465c4eb176f1dcc9b70c1a45c1e2 in try block, falling back to the old one.

Using explicit block so that it can be easily dropped in the future.
