### PR TITLE
Fix SyntaxWarning: invalid escape sequence '\*'

### DIFF
--- a/gui/filehandling.py
+++ b/gui/filehandling.py
@@ -287,8 +287,8 @@ class _IOProgressUI:
         """Call a save or load callable and watch its progress.
 
         :param callable func: The IO function to be called.
-        :param \*args: Passed to func.
-        :param \*\*kwargs: Passed to func.
+        :param *args: Passed to func.
+        :param **kwargs: Passed to func.
         :returns: The return value of func.
 
         Messages about the operation in progress may be shown to the

--- a/gui/mode.py
+++ b/gui/mode.py
@@ -676,7 +676,7 @@ class BrushworkModeMixin(InteractionMode):
     def __init__(self, **kwds):
         """Cooperative init (this mixin initializes some private fields)
 
-        :param bool \*\*kwds: Passed through to other __init__s.
+        :param bool **kwds: Passed through to other __init__s.
 
         """
         super(BrushworkModeMixin, self).__init__(**kwds)
@@ -1284,7 +1284,7 @@ class OneshotDragMode(DragMode):
     def __init__(self, unmodified_persist=True, temporary_activation=True, **kwargs):
         """
         :param bool unmodified_persist: Stay active if entered without modkeys
-        :param bool \*\*kwargs: Passed through to other __init__s.
+        :param bool **kwargs: Passed through to other __init__s.
 
         If unmodified_persist is true, and drag mode is spring-loaded, the
         tool will stay active if no modifiers were held initially. This means
@@ -1355,7 +1355,7 @@ class ModeStack(object):
         """Syncs pending changes with the model
 
         :param Document model: the requesting model
-        :param \*\*kwargs: passed through to checkpoint()
+        :param **kwargs: passed through to checkpoint()
 
         This issues a `checkpoint()` on the current InteractionMode.
         """

--- a/gui/stategroup.py
+++ b/gui/stategroup.py
@@ -132,7 +132,7 @@ class State(object):
         """Activate a State from an action or a button press event.
 
         :param action_or_event: A Gtk.Action, or a Gdk.Event.
-        :param \*\*kwargs: passed to enter().
+        :param **kwargs: passed to enter().
 
         For events, only button press events are supported by this code.
 

--- a/lib/autosave.py
+++ b/lib/autosave.py
@@ -73,7 +73,7 @@ class Autosaveable:
         :param lib.idletask.Processor taskproc: Output: queue of tasks
         :param set manifest: Output: files in data/ to retain afterward
         :param tuple bbox: frame bounding box, (x,y,w,h)
-        :param \*\*kwargs: To be passed to underlying save routines.
+        :param **kwargs: To be passed to underlying save routines.
         :rtype: xml.etree.ElementTree.Element
         :returns: Element indexing files when written (for stack.xml)
 

--- a/lib/document.py
+++ b/lib/document.py
@@ -1139,7 +1139,7 @@ class Document(object):
         By default, the request to flush changes is non-optional.
 
         :param bool flush: if this is False, the flush is optional too
-        :param \*\*kwargs: passed through to observers
+        :param **kwargs: passed through to observers
 
         See: `lib.observable.event` for details of the signalling
         mechanism.
@@ -1943,7 +1943,7 @@ class Document(object):
         :param progress: Unsized progress object: updates UI.
         :type progress: lib.feedback.Progress or None
         :param bool retain_autosave_info: Restore unsaved time etc.
-        :param \*\*kwargs: Passed through to layer loader methods.
+        :param **kwargs: Passed through to layer loader methods.
 
         The oradir folder is treated as read-only during this operation.
 
@@ -2032,7 +2032,7 @@ def _save_layers_to_new_orazip(
     :param frame_active: True if the frame is enabled
     :param progress: Unsized UI feedback object
     :type progress: lib.feedback.Progress or None
-    :param \*\*kwargs: Passed through to root_stack.save_to_openraster()
+    :param **kwargs: Passed through to root_stack.save_to_openraster()
     :rtype: GdkPixbuf
     :returns: Thumbnail preview image (256x256 max) of what was saved
 

--- a/lib/observable.py
+++ b/lib/observable.py
@@ -655,7 +655,7 @@ class ObservableDict(dict):
         default, the request to flush changes is non-optional.
 
         :param bool flush: if this is False, the flush is optional too
-        :param \*\*kwargs: passed through to observers
+        :param **kwargs: passed through to observers
 
         See: `lib.observable.event` for details of the signalling
         mechanism.

--- a/lib/pixbuf.py
+++ b/lib/pixbuf.py
@@ -46,7 +46,7 @@ def save(pixbuf, filename, type="png", **kwargs):
     :param GdkPixbuf.Pixbuf pixbuf: the pixbuf to save
     :param unicode filename: file path to save as
     :param str type: type to save as: 'jpeg'/'png'/...
-    :param \*\*kwargs: passed through to GdkPixbuf
+    :param **kwargs: passed through to GdkPixbuf
     :rtype: bool
     :returns: whether the file was saved fully
 

--- a/lib/surface.py
+++ b/lib/surface.py
@@ -85,8 +85,8 @@ class TileBlittable(Bounded):
         :param bool dst_has_alpha: destination has an alpha channel
         :param int tx: Tile X coord (multiply by TILE_SIZE for pixels)
         :param int ty: Tile Y coord (multiply by TILE_SIZE for pixels)
-        :param \*args: Implementation may extend this interface
-        :param \*\*kwargs: Implementation may extend this interface
+        :param *args: Implementation may extend this interface
+        :param **kwargs: Implementation may extend this interface
 
         The destination is typically of dimensions NxNx4, and is
         typically of type uint16 or uint8. Implementations are expected
@@ -120,8 +120,8 @@ class TileCompositable(Bounded):
         :param int tx: Tile X coord (multiply by TILE_SIZE for pixels)
         :param int ty: Tile Y coord (multiply by TILE_SIZE for pixels)
         :param int mode: mode to use when compositing
-        :param \*args: Implementation may extend this interface
-        :param \*\*kwargs: Implementation may extend this interface
+        :param *args: Implementation may extend this interface
+        :param **kwargs: Implementation may extend this interface
 
         Composite one tile of this surface over the array dst, modifying
         only dst. Unlike `blit_tile_into()`, this method must respect
@@ -161,7 +161,7 @@ def scanline_strips_iter(
     :param TileBlittable surface: Surface to iterate over
     :param bool alpha: If true, write a PNG with alpha
     :param bool single_tile_pattern: True if surface is a one tile only.
-    :param tuple \*\*kwargs: Passed to blit_tile_into.
+    :param tuple **kwargs: Passed to blit_tile_into.
 
     The `alpha` parameter is passed to the surface's `blit_tile_into()`.
     Rendering is skipped for all but the first line of single-tile patterns.
@@ -222,13 +222,13 @@ def save_as_png(surface, filename, *rect, **kwargs):
 
     :param TileBlittable surface: Surface to save
     :param unicode filename: The file to write
-    :param tuple \*rect: Rectangle (x, y, w, h) to save
+    :param tuple *rect: Rectangle (x, y, w, h) to save
     :param bool alpha: If true, write a PNG with alpha
     :param progress: Updates a UI every scanline strip.
     :type progress: lib.feedback.Progress or None
     :param bool single_tile_pattern: True if surface is one tile only.
     :param bool save_srgb_chunks: Set to False to not save sRGB flags.
-    :param tuple \*\*kwargs: Passed to blit_tile_into (minus the above)
+    :param tuple **kwargs: Passed to blit_tile_into (minus the above)
 
     The `alpha` parameter is passed to the surface's `blit_tile_into()`
     method, as well as to the PNG writer.  Rendering is

--- a/lib/tiledsurface.py
+++ b/lib/tiledsurface.py
@@ -544,7 +544,7 @@ class MyPaintSurface(TileAccessible, TileBlittable, TileCompositable):
         :param bool convert_to_srgb: If True, convert to sRGB
         :param progress: Unsized UI feedback obj.
         :type progress: lib.feedback.Progress or None
-        :param dict \*\*kwargs: Ignored
+        :param dict **kwargs: Ignored
 
         Raises a `lib.errors.FileHandlingError` with a descriptive
         string when conversion or PNG reading fails.


### PR DESCRIPTION
These made doctests slighly more noisy.

Fixes: https://github.com/mypaint/mypaint/issues/1312
